### PR TITLE
Create AzureHttpClient singleton

### DIFF
--- a/Notify/Notify/Notify.Android/AndroidLocationService.cs
+++ b/Notify/Notify/Notify.Android/AndroidLocationService.cs
@@ -28,8 +28,8 @@ namespace Notify.Droid
             Task.Run(() => {
                 try
                 {
-                    var locShared = new LocationService();
-                    locShared.Run(_cts.Token).Wait();
+                    LocationService locationService = new LocationService();
+                    locationService.Run(_cts.Token).Wait();
                 }
                 catch (OperationCanceledException)
                 {

--- a/Notify/Notify/Notify/AppShell.xaml.cs
+++ b/Notify/Notify/Notify/AppShell.xaml.cs
@@ -112,7 +112,7 @@ namespace Notify
             {
                 bool arrived;
 
-                if (isCurrentLocationFarEnoughForUpdating(location))
+                if (requiresLocationUpdate(location))
                 {
                     Debug.WriteLine($"{location}, {DateTime.Now.ToLongTimeString()}");
                     arrived = AzureHttpClient.Instance.CheckIfArrivedDestination(location);
@@ -138,7 +138,7 @@ namespace Notify
             });
         }
         
-        bool isCurrentLocationFarEnoughForUpdating(Location location)
+        bool requiresLocationUpdate(Location location)
         {
             bool shouldUpdate;
 
@@ -151,10 +151,10 @@ namespace Notify
                 double distance = GeolocatorUtils.CalculateDistance(
                     latitudeStart: location.Latitude, longitudeStart: location.Longitude,
                     latitudeEnd: location.Latitude, longitudeEnd: m_LastUpdatedLocation.Longitude,
-                    units: GeolocatorUtils.DistanceUnits.Kilometers) * 1000;
+                    units: GeolocatorUtils.DistanceUnits.Kilometers) * Constants.METERS_IN_KM;
             
                 Debug.WriteLine($"Distance from last updated location: {distance} meters");
-                shouldUpdate = distance > 30;
+                shouldUpdate = distance > Constants.DISTANCE_UPDATE_THRESHOLD;
             }
 
             return shouldUpdate;
@@ -162,7 +162,7 @@ namespace Notify
 
         private void AnnounceDestinationArrival()
         {
-            notificationManager.SendNotification("Destination arrived!", "You're arrived at your destination");
+            notificationManager.SendNotification("Destination arrived!", "You've arrived at your destination");
             Debug.WriteLine("You've arrived at your destination!");
         }
 

--- a/Notify/Notify/Notify/AppShell.xaml.cs
+++ b/Notify/Notify/Notify/AppShell.xaml.cs
@@ -1,16 +1,15 @@
 ﻿using System;
 using System.Diagnostics;
-using System.Net.Http;
-using System.Text;
-using System.Threading.Tasks;
-using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
+using Notify.Helpers;
+using Notify.HttpClient;
 using Notify.Notifications;
 using Notify.Views;
+using Plugin.Geolocator.Abstractions;
 using Xamarin.Essentials;
 using Xamarin.Forms;
 using Xamarin.Forms.Xaml;
 using DriverDetailsPage = Notify.Views.DriverDetailsPage;
+using Location = Notify.Core.Location;
 using ProfilePage = Notify.Views.ProfilePage;
 using TeamDetailsPage = Notify.Views.TeamDetailsPage;
 
@@ -20,10 +19,7 @@ namespace Notify
     public partial class AppShell : Shell
     {
         private readonly INotificationManager notificationManager = DependencyService.Get<INotificationManager>();
-        private readonly Location goalLocation = new Location(latitude: 32.02069, longitude: 34.763419999999996);
-        private bool arrivedDestination = false;
-        private HttpClient httpClient = new HttpClient();
-        private LocationMessage currentLocation = null;
+        private Location m_LastUpdatedLocation = null;
         
         public AppShell()
         {
@@ -33,12 +29,10 @@ namespace Notify
             setNoficicationManagerNotificationReceived();
             setMessagingCenterSubscriptions();
 
-            if (Preferences.Get("LocationServiceRunning", false) == true)
+            if (Preferences.Get(Constants.START_LOCATION_SERVICE, false))
             {
                 StartService();
             }
-
-            httpClient.BaseAddress = new Uri("https://notifymta.azurewebsites.net/api/");
         }
 
         void RegisterRoutes()
@@ -52,13 +46,13 @@ namespace Notify
         
         private void setMessagingCenterSubscriptions()
         {
-            setMessagingCenterLocationMessageSubscription();
+            setMessagingCenterLocationSubscription();
             setMessagingCenterStopServiceMessageSubscription();
             setMessagingCenterLocationErrorMessageSubscription();
             setMessagingCenterLocationArrivedMessageSubscription();
         }
         
-                private void setMessagingCenterLocationArrivedMessageSubscription()
+        private void setMessagingCenterLocationArrivedMessageSubscription()
         {
             MessagingCenter.Subscribe<LocationArrivedMessage>(this, "LocationArrived", message =>
             {
@@ -66,11 +60,11 @@ namespace Notify
                 {
                     try
                     {
-                        Debug.Write("You've arrived your destination!");
+                        Debug.Write("You've arrived at your destination!");
                     }
                     catch (Exception ex)
                     {
-                        Debug.Write("Failed in MessagingCenter.Subscribe<LocationArrivedMessage>: " + ex.Message);
+                        Debug.Write($"Failed in MessagingCenter.Subscribe<LocationArrivedMessage>: {ex.Message}");
                     }
                 });
             });
@@ -88,7 +82,7 @@ namespace Notify
                     }
                     catch (Exception ex)
                     {
-                        Debug.Write("Failed in MessagingCenter.Subscribe<LocationErrorMessage>: " + ex.Message);
+                        Debug.Write($"Failed in MessagingCenter.Subscribe<LocationErrorMessage>: {ex.Message}");
                     }
                 });
             });
@@ -106,82 +100,70 @@ namespace Notify
                     }
                     catch (Exception ex)
                     {
-                        Debug.Write("Failed in MessagingCenter.Subscribe<StopServiceMessage>: " + ex.Message);
+                        Debug.Write($"Failed in MessagingCenter.Subscribe<StopServiceMessage>: {ex.Message}");
                     }
                 });
             });
         }
 
-        private void setMessagingCenterLocationMessageSubscription()
+        private void setMessagingCenterLocationSubscription()
         {
-            MessagingCenter.Subscribe<LocationMessage>(this, "Location", location =>
+            MessagingCenter.Subscribe<Location>(this, "Location", location =>
             {
-                if (currentLocation != location)
+                bool arrived;
+
+                if (isCurrentLocationFarEnoughForUpdating(location))
                 {
-                    currentLocation = location;
-                    Debug.WriteLine($"{location.Latitude}, {location.Longitude}, {DateTime.Now.ToLongTimeString()}");
-                    double distance = sendCurrentLocationToAzureFunction(location).Result;
-                    if (checkIfArrivedDestinationForTheFirstTime(distance))
+                    Debug.WriteLine($"{location}, {DateTime.Now.ToLongTimeString()}");
+                    arrived = AzureHttpClient.Instance.CheckIfArrivedDestination(location);
+                    
+                    if (arrived)
                     {
                         Device.BeginInvokeOnMainThread(() =>
                         {
                             try
                             {
-                                arrivedDestinationForTheFirstTime();
+                                AnnounceDestinationArrival();
                             }
                             catch (Exception ex)
                             {
-                                Debug.WriteLine("Failed in MessagingCenter.Subscribe<LocationMessage>: " + ex.Message);
+                                Debug.WriteLine($"Failed in MessagingCenter.Subscribe<Location>: {ex.Message}");
                             }
                         });
                     }
+                    
+                    m_LastUpdatedLocation = location;
+                    Debug.WriteLine($"Updated last updated location: {m_LastUpdatedLocation}");
                 }
             });
         }
         
-        private async Task<double> sendCurrentLocationToAzureFunction(LocationMessage currentLocation)
+        bool isCurrentLocationFarEnoughForUpdating(Location location)
         {
-            double distance = -1;
+            bool shouldUpdate;
 
-            try
+            if (m_LastUpdatedLocation == null)
             {
-                dynamic request = new JObject();
-                request.location = new JObject();
-                request.location.latitude = currentLocation.Latitude;
-                request.location.longitude = currentLocation.Longitude;
-                string json = JsonConvert.SerializeObject(request);
-                StringContent content = new StringContent(json, Encoding.UTF8, "application/json");
-
-                // Send an HTTP POST request to the Azure Function
-                HttpResponseMessage response = await httpClient.PostAsync("distance", content).ConfigureAwait(false);
-                response.EnsureSuccessStatusCode();
-
-                // Read the response JSON
-                string responseJson = await response.Content.ReadAsStringAsync();
-                dynamic output = JsonConvert.DeserializeObject(responseJson);
-
-                // Extract the distance value from the output JSON
-                distance = Convert.ToDouble(output.distance);
+                shouldUpdate = true;
             }
-            catch (Exception ex)
+            else
             {
-                DisplayAlert("Error", $"An error occurred: {ex.Message}", "OK");
+                double distance = GeolocatorUtils.CalculateDistance(
+                    latitudeStart: location.Latitude, longitudeStart: location.Longitude,
+                    latitudeEnd: location.Latitude, longitudeEnd: m_LastUpdatedLocation.Longitude,
+                    units: GeolocatorUtils.DistanceUnits.Kilometers) * 1000;
+            
+                Debug.WriteLine($"Distance from last updated location: {distance} meters");
+                shouldUpdate = distance > 30;
             }
 
-            return distance;
+            return shouldUpdate;
         }
-        
-        private void arrivedDestinationForTheFirstTime()
-        {
-            notificationManager.SendNotification("Destination arrived!", "You're arrived your destination");
-            Debug.WriteLine("You've arrived your destination!");
 
-            arrivedDestination = true;
-        }
-        
-        private bool checkIfArrivedDestinationForTheFirstTime(double distance)
+        private void AnnounceDestinationArrival()
         {
-            return !arrivedDestination && (int)distance != -1 && distance <= 50 ;
+            notificationManager.SendNotification("Destination arrived!", "You're arrived at your destination");
+            Debug.WriteLine("You've arrived at your destination!");
         }
 
         private void setNoficicationManagerNotificationReceived()
@@ -200,15 +182,17 @@ namespace Notify
 
             try
             {
-                MessagingCenter.Send(startServiceMessage, "ServiceStarted");
-                Preferences.Set("LocationServiceRunning", true);
+                if (Preferences.Get(Constants.START_LOCATION_SERVICE, false))
+                {
+                    MessagingCenter.Send(startServiceMessage, "ServiceStarted");
+                    Preferences.Set(Constants.START_LOCATION_SERVICE, false);
 
-                Debug.WriteLine("Location Service has been started!");
-                Debug.WriteLine($"Goal destination: {goalLocation.Latitude},{goalLocation.Longitude}");
+                    Debug.WriteLine("Location Service has been started!");
+                }
             }
-            catch (Exception e)
+            catch (Exception ex)
             {
-                Debug.WriteLine(e.Message);
+                Debug.WriteLine(ex.Message);
             }
         }
 

--- a/Notify/Notify/Notify/Core/HttpClientFactorry.cs
+++ b/Notify/Notify/Notify/Core/HttpClientFactorry.cs
@@ -1,17 +1,15 @@
-using System.Net.Http;
-
 namespace Notify.Core
 {
     public class HttpClientFactory
     {
-        private readonly HttpClient _httpClient;
+        private readonly System.Net.Http.HttpClient _httpClient;
 
         public HttpClientFactory()
         {
-            _httpClient = new HttpClient();
+            _httpClient = new System.Net.Http.HttpClient();
         }
 
-        public HttpClient GetHttpClient()
+        public System.Net.Http.HttpClient GetHttpClient()
         {
             return _httpClient;
         }

--- a/Notify/Notify/Notify/Core/Location.cs
+++ b/Notify/Notify/Notify/Core/Location.cs
@@ -1,0 +1,19 @@
+namespace Notify.Core
+{
+    public class Location
+    {
+        public double Longitude { get; }
+        public double Latitude { get; }
+
+        public Location(double longitude, double latitude)
+        {
+            Longitude = longitude;
+            Latitude = latitude;
+        }
+
+        public override string ToString()
+        {
+            return $"Longitude: {Longitude}, Latitude: {Latitude}";
+        }
+    }
+}

--- a/Notify/Notify/Notify/Helpers/Constants.cs
+++ b/Notify/Notify/Notify/Helpers/Constants.cs
@@ -70,7 +70,26 @@ namespace Notify.Helpers
 
         #endregion
 
-        public static readonly string Username = "lin";
-        public static readonly string Password = "123";
+        public static readonly string USERNAME = "lin";
+        public static readonly string PASSWORD = "123";
+
+        #region Http Client
+
+        public static readonly string AZURE_FUNCTIONS_APP_BASE_URL = "https://notifymta.azurewebsites.net/api/";
+        public static readonly string AZURE_FUNCTIONS_PATTERN_DISTANCE = "distance";
+
+        #endregion
+
+        #region Values
+
+        public static readonly int DESTINATION_MAXMIMUM_DISTANCE = 50;
+        
+        #endregion
+
+        #region Services
+
+        public static readonly string START_LOCATION_SERVICE = "LocationServiceRunning";
+
+        #endregion
     }
 }

--- a/Notify/Notify/Notify/Helpers/Constants.cs
+++ b/Notify/Notify/Notify/Helpers/Constants.cs
@@ -83,6 +83,8 @@ namespace Notify.Helpers
         #region Values
 
         public static readonly int DESTINATION_MAXMIMUM_DISTANCE = 50;
+        public static readonly int DISTANCE_UPDATE_THRESHOLD = 30;
+        public static readonly int METERS_IN_KM = 1000;
         
         #endregion
 

--- a/Notify/Notify/Notify/HttpClient/AzureHttpClient.cs
+++ b/Notify/Notify/Notify/HttpClient/AzureHttpClient.cs
@@ -1,0 +1,103 @@
+using System;
+using System.Diagnostics;
+using System.Net.Http;
+using System.Text;
+using System.Threading.Tasks;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using Notify.Helpers;
+using Notify.Core;
+
+namespace Notify.HttpClient
+{
+    public class AzureHttpClient
+    {
+        private static AzureHttpClient m_Instance;
+        private static readonly object r_LockInstanceCreation = new object();
+        private static System.Net.Http.HttpClient m_HttpClient;
+
+        private AzureHttpClient()
+        {
+            m_HttpClient = new System.Net.Http.HttpClient
+            {
+                BaseAddress = new Uri(Constants.AZURE_FUNCTIONS_APP_BASE_URL)
+            };
+        }
+
+        public static AzureHttpClient Instance
+        {
+            get
+            {
+                if (m_Instance == null)
+                {
+                    lock (r_LockInstanceCreation)
+                    {
+                        if (m_Instance == null)
+                        {
+                            m_Instance = new AzureHttpClient();
+                        }
+                    }
+                }
+
+                return m_Instance;
+            }
+        }
+
+        public bool CheckIfArrivedDestination(Location location)
+        {
+            dynamic request = new JObject();
+            string json;
+            HttpResponseMessage response;
+            dynamic returnedObject;
+            double distance;
+            bool arrived;
+
+            try
+            {
+                request.location = new JObject();
+                request.location.latitude = location.Latitude;
+                request.location.longitude = location.Longitude;
+                json = JsonConvert.SerializeObject(request);
+                Debug.WriteLine($"request:{Environment.NewLine}{request}");
+
+                response = postAsync(
+                    requestUri: Constants.AZURE_FUNCTIONS_PATTERN_DISTANCE, 
+                    content: createJsonStringContent(json)
+                    ).Result;
+
+                response.EnsureSuccessStatusCode();
+                Debug.WriteLine($"Successful status code from Azure Function from GetDistanceToDestinationFromCurrentLocation, location: {location}!");
+
+                returnedObject = DeserializeObjectFromResponseAsync(response).Result;
+                distance = Convert.ToDouble(returnedObject.distance);
+                Debug.WriteLine($"distance: {distance}");
+
+                arrived = distance <= Constants.DESTINATION_MAXMIMUM_DISTANCE;
+            }
+            catch (Exception ex)
+            {
+                Debug.WriteLine($"Error occured on GetDistanceToDestinationFromCurrentLocation, {location}:{Environment.NewLine}{ex.Message}");
+                arrived = false;
+            }
+
+            return arrived;
+        }
+
+        private async Task<HttpResponseMessage> postAsync(string requestUri, StringContent content)
+        {
+            HttpResponseMessage response = await m_HttpClient.PostAsync(requestUri, content).ConfigureAwait(false);
+            return response;
+        }
+
+        private async Task<dynamic> DeserializeObjectFromResponseAsync(HttpResponseMessage response)
+        {
+            string responseJson = await response.Content.ReadAsStringAsync();
+            return JsonConvert.DeserializeObject(responseJson);
+        }
+
+        private StringContent createJsonStringContent(string json)
+        {
+            return new StringContent(json, Encoding.UTF8, "application/json");
+        }
+    }
+}

--- a/Notify/Notify/Notify/Messages.cs
+++ b/Notify/Notify/Notify/Messages.cs
@@ -8,18 +8,11 @@ namespace Notify
     {
     }
 
-    public class LocationMessage
-    {
-        public double Latitude { get; set; }
-        public double Longitude { get; set; }
-    }
-
     public class LocationErrorMessage
     {
     }
     
     public class LocationArrivedMessage
     {
-
     }
 }

--- a/Notify/Notify/Notify/Services/Location/LocationServices.cs
+++ b/Notify/Notify/Notify/Services/Location/LocationServices.cs
@@ -88,11 +88,11 @@ namespace Notify
             {
                 if (Preferences.Get(Constants.START_LOCATION_SERVICE, false) == false)
                 {
-                    StartService();
+                    startService();
                 }
                 else
                 {
-                    StopService();
+                    stopService();
                 }
             }
         }
@@ -125,25 +125,25 @@ namespace Notify
 
                 if (Preferences.Get(Constants.START_LOCATION_SERVICE, false))
                 {
-                    StartService();
+                    startService();
                 }
             }
         }
 
-        public void StartService()
+        private void startService()
         {
             StartServiceMessage message = new StartServiceMessage();
             MessagingCenter.Send(message, "Location service started!");
             Preferences.Set(Constants.START_LOCATION_SERVICE, true);
-            Debug.WriteLine("Location service as been started!");
+            Debug.WriteLine("Location service has been started!");
         }
-        
-        public void StopService()
+
+        private void stopService()
         {
             StopServiceMessage message = new StopServiceMessage();
             MessagingCenter.Send(message, "Location service stopped!");
             Preferences.Set(Constants.START_LOCATION_SERVICE, false);
-            Debug.WriteLine("Location service as been stopped!");
+            Debug.WriteLine("Location service has been stopped!");
         }
     }
 }

--- a/Notify/Notify/Notify/ViewModels/WelcomePageViewModel.cs
+++ b/Notify/Notify/Notify/ViewModels/WelcomePageViewModel.cs
@@ -59,7 +59,7 @@ namespace Notify.ViewModels
             {
                 try
                 {
-                    if (m_UserName.Equals(Constants.Username) && Password.Equals(Constants.Password))
+                    if (m_UserName.Equals(Constants.USERNAME) && Password.Equals(Constants.PASSWORD))
                     {
                         await locationService.ManageLocationTracking();
                         await Shell.Current.GoToAsync("///main");
@@ -91,6 +91,7 @@ namespace Notify.ViewModels
         private async Task initialize()
         {
             locationService = new LocationService();
+
             VersionTracking.Track();
             if (VersionTracking.IsFirstLaunchEver)
             {

--- a/Notify/Notify/Notify/Views/WelcomePage.xaml.cs
+++ b/Notify/Notify/Notify/Views/WelcomePage.xaml.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using Notify.Views.TabViews;
-using Xamarin.Forms;
+﻿using Xamarin.Forms;
 using Xamarin.Forms.Xaml;
 
 namespace Notify.Views


### PR DESCRIPTION
## Description: 
- Converted the HttpClient to a singleton.
- Implemented changes to send HTTP request to Azure Functions app only if the current location is over 30 meters of the last location of the last request.

## Type of change:
- [ ] Bug fix
- [ ] New feature
- [x] Fix/new infrastructure

## Background context of the changes:
- For making the HttpClient available to all our app's pages, I've created a class called "AzureHttpClient", so every page could use the same HttpClient, instead of creating the same instance, with the same logic over and over again.
- For reducing the load on our Azure Function, an HTTP request will be sent only if the current location is over 30 meters on the last request sent.

## Scenarios that were tested during this implementation:
All different modes of the application (running, in the background and killed)
