### PR TITLE
Upgrade Notify .NET version from 6 to 7

### DIFF
--- a/Notify/global.json
+++ b/Notify/global.json
@@ -1,0 +1,7 @@
+{
+  "sdk": {
+    "version": "7.0.0",
+    "rollForward": "latestMajor",
+    "allowPrerelease": false
+  }
+}


### PR DESCRIPTION
## Description: 
Upgrading the version of Notify's .NET from 6 to 7.

## Type of change:
- [ ] Bug fix
- [ ] New feature
- [x] Fix/new infrastructure

## Background context of the changes:
For using Google Maps map usage, we need to use .NET 7.
