### PR TITLE
Add friends' permissions mechanism

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,7 +6,7 @@ name: Build and deploy dotnet core app to Azure Function App - NotifyMTA
 on:
   push:
     branches:
-      - feature/*
+      - master
   workflow_dispatch:
 
 env:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,27 +6,26 @@ name: Build and deploy dotnet core app to Azure Function App - NotifyMTA
 on:
   push:
     branches:
-      - master
+      - feature/*
   workflow_dispatch:
 
 env:
-  AZURE_FUNCTIONAPP_PACKAGE_PATH: './Notify/Notify.Functions/Notify.Functions' # set this to the path to your web app project, defaults to the repository root
-  DOTNET_VERSION: '6.0.x' # set this to the dotnet version to use
+  AZURE_FUNCTIONAPP_PACKAGE_PATH: './Notify/Notify.Functions/Notify.Functions'
+  DOTNET_VERSION: '6.0.x'
 
 jobs:
   build-and-deploy:
-    runs-on: windows-latest
+    runs-on: ubuntu-latest
     steps:
       - name: 'Checkout GitHub Action'
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Setup DotNet ${{ env.DOTNET_VERSION }} Environment
-        uses: actions/setup-dotnet@v1
+        uses: actions/setup-dotnet@v3
         with:
           dotnet-version: ${{ env.DOTNET_VERSION }}
 
       - name: 'Resolve Project Dependencies Using Dotnet'
-        shell: pwsh
         run: |
           pushd './${{ env.AZURE_FUNCTIONAPP_PACKAGE_PATH }}'
           dotnet build --configuration Release --output ./output
@@ -40,4 +39,3 @@ jobs:
           slot-name: 'Production'
           package: '${{ env.AZURE_FUNCTIONAPP_PACKAGE_PATH }}/output'
           publish-profile: ${{ secrets.Azure }}
-          

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,12 +10,13 @@ on:
   workflow_dispatch:
 
 env:
+  AZURE_FUNCTIONAPP_NAME: 'NotifyMTA'
   AZURE_FUNCTIONAPP_PACKAGE_PATH: './Notify/Notify.Functions/Notify.Functions'
   DOTNET_VERSION: '6.0.x'
 
 jobs:
   build-and-deploy:
-    runs-on: ubuntu-latest
+    runs-on: windows-latest
     steps:
       - name: 'Checkout GitHub Action'
         uses: actions/checkout@v3
@@ -26,6 +27,7 @@ jobs:
           dotnet-version: ${{ env.DOTNET_VERSION }}
 
       - name: 'Resolve Project Dependencies Using Dotnet'
+        shell: pwsh
         run: |
           pushd './${{ env.AZURE_FUNCTIONAPP_PACKAGE_PATH }}'
           dotnet build --configuration Release --output ./output
@@ -35,7 +37,7 @@ jobs:
         uses: Azure/functions-action@v1
         id: fa
         with:
-          app-name: 'NotifyMTA'
-          slot-name: 'Production'
+          app-name: ${{ env.AZURE_FUNCTIONAPP_NAME }}
           package: '${{ env.AZURE_FUNCTIONAPP_PACKAGE_PATH }}/output'
           publish-profile: ${{ secrets.Azure }}
+          

--- a/Notify/Notify.Functions/Notify.Functions/Core/Constants.cs
+++ b/Notify/Notify.Functions/Notify.Functions/Core/Constants.cs
@@ -1,5 +1,3 @@
-using Twilio.Rest.Api.V2010.Account.AvailablePhoneNumberCountry;
-
 namespace Notify.Functions.Core
 {
     public static class Constants
@@ -10,7 +8,7 @@ namespace Notify.Functions.Core
         public static readonly string COLLECTION_USER = "User";
         public static readonly string COLLECTION_FRIEND = "Friend";
         public static readonly string COLLECTION_FRIEND_REQUEST = "Friend_Request";
-        public static readonly string COLLECTION_GROUP = "Group";
+        public static readonly string COLLECTION_PERMISSION = "Permission";
         public static readonly string ENCRYPT_OPERATION = "encrypt";
         public static readonly string DECRYPT_OPERATION = "decrypt";
         public static readonly string AZURE_BLOB_CONTAINER_NAME = "notifycontainer";
@@ -33,6 +31,23 @@ namespace Notify.Functions.Core
 
         public static readonly string GOOGLE_API_BASE_URL = "https://maps.googleapis.com/maps/api/";
         public static readonly int GOOGLE_API_RADIUS = 1000;
+
+        #endregion
+
+        #region Values
+
+        public static readonly string PERMISSION_ALLOW = "Allow";
+        public static readonly string PERMISSION_ALLOW_LOWER = PERMISSION_ALLOW.ToLower();
+        public static readonly string PERMISSION_DISALLOW = "Disallow";
+        public static readonly string PERMISSION_DISALLOW_LOWER = PERMISSION_DISALLOW.ToLower();
+        public static readonly string NOTIFICATION_TYPE_LOCATION = "Location";
+        public static readonly string NOTIFICATION_TYPE_LOCATION_LOWER = NOTIFICATION_TYPE_LOCATION.ToLower();
+        public static readonly string NOTIFICATION_TYPE_TIME = "Time";
+        public static readonly string NOTIFICATION_TYPE_TIME_LOWER = NOTIFICATION_TYPE_TIME.ToLower();
+        public static readonly string NOTIFICATION_TYPE_DYNAMIC = "Dynamic";
+        public static readonly string NOTIFICATION_TYPE_DYNAMIC_LOWER = NOTIFICATION_TYPE_DYNAMIC.ToLower();
+        public static readonly string NOTIFICATION_STATUS_ACTIVE = "Active";
+        public static readonly string NOTIFICATION_STATUS_PENDING = "Pending";
 
         #endregion
     }

--- a/Notify/Notify.Functions/Notify.Functions/Core/Constants.cs
+++ b/Notify/Notify.Functions/Notify.Functions/Core/Constants.cs
@@ -46,6 +46,8 @@ namespace Notify.Functions.Core
         public static readonly string NOTIFICATION_TYPE_TIME_LOWER = NOTIFICATION_TYPE_TIME.ToLower();
         public static readonly string NOTIFICATION_TYPE_DYNAMIC = "Dynamic";
         public static readonly string NOTIFICATION_TYPE_DYNAMIC_LOWER = NOTIFICATION_TYPE_DYNAMIC.ToLower();
+        public static readonly string NOTIFICATION_TYPE_WIFI = "WiFi";
+        public static readonly string NOTIFICATION_TYPE_BLUETOOTH = "Bluetooth";
         public static readonly string NOTIFICATION_STATUS_ACTIVE = "Active";
         public static readonly string NOTIFICATION_STATUS_PENDING = "Pending";
 

--- a/Notify/Notify.Functions/Notify.Functions/NotifyFunctions/Destination/UpdateDestination.cs
+++ b/Notify/Notify.Functions/Notify.Functions/NotifyFunctions/Destination/UpdateDestination.cs
@@ -78,7 +78,7 @@ namespace Notify.Functions.NotifyFunctions.Destination
             
             log.LogInformation($"Found existing document for user {data.user} and location {data.location.name}. Updating it");
 
-            if (type.Equals("Location"))
+            if (type.Equals(Constants.NOTIFICATION_TYPE_LOCATION))
             {
                 double latitude = Convert.ToDouble(data.location.latitude), longitude = Convert.ToDouble(data.location.longitude);
                 string address = GoogleHttpClient.Instance.GetAddressFromCoordinatesAsync(latitude, longitude, log).Result;
@@ -87,11 +87,11 @@ namespace Notify.Functions.NotifyFunctions.Destination
                 document["location"].AsBsonDocument["longitude"] = longitude;
                 document["location"].AsBsonDocument["address"] = address;
             }
-            else if (type.Equals("WiFi"))
+            else if (type.Equals(Constants.NOTIFICATION_TYPE_WIFI))
             {
                 document["location"].AsBsonDocument["ssid"] = Convert.ToString(data.location.ssid);
             }
-            else if (type.Equals("Bluetooth"))
+            else if (type.Equals(Constants.NOTIFICATION_TYPE_BLUETOOTH))
             {
                 document["location"].AsBsonDocument["device"] = Convert.ToString(data.location.device);
             }
@@ -121,7 +121,7 @@ namespace Notify.Functions.NotifyFunctions.Destination
                 }
             };
 
-            if (type.Equals("Location"))
+            if (type.Equals(Constants.NOTIFICATION_TYPE_LOCATION))
             {
                 double latitude = Convert.ToDouble(data.location.latitude), longitude = Convert.ToDouble(data.location.longitude);
                 string address = GoogleHttpClient.Instance.GetAddressFromCoordinatesAsync(latitude, longitude, log).Result;
@@ -130,11 +130,11 @@ namespace Notify.Functions.NotifyFunctions.Destination
                 document["location"].AsBsonDocument.Add("longitude", longitude);
                 document["location"].AsBsonDocument.Add("address", address);
             }
-            else if (type.Equals("WiFi"))
+            else if (type.Equals(Constants.NOTIFICATION_TYPE_WIFI))
             {
                 document["location"].AsBsonDocument.Add("ssid", Convert.ToString(data.location.ssid));
             }
-            else if (type.Equals("Bluetooth"))
+            else if (type.Equals(Constants.NOTIFICATION_TYPE_BLUETOOTH))
             {
                 document["location"].AsBsonDocument.Add("device", Convert.ToString(data.location.device));
             }

--- a/Notify/Notify.Functions/Notify.Functions/NotifyFunctions/Friend/DeleteFriend.cs
+++ b/Notify/Notify.Functions/Notify.Functions/NotifyFunctions/Friend/DeleteFriend.cs
@@ -42,7 +42,7 @@ namespace Notify.Functions.NotifyFunctions.Friend
             }
             else
             {
-                message = $"Friendship and permissions between {username} and {friendName} was deleted";
+                message = $"Friendship and permissions between {username} and {friendName} were deleted";
                 result = new OkObjectResult(message);
             }
             

--- a/Notify/Notify.Functions/Notify.Functions/NotifyFunctions/Friend/DeleteFriend.cs
+++ b/Notify/Notify.Functions/Notify.Functions/NotifyFunctions/Friend/DeleteFriend.cs
@@ -1,5 +1,3 @@
-using System;
-using System.IO;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
@@ -9,9 +7,7 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging;
 using MongoDB.Bson;
 using MongoDB.Driver;
-using Newtonsoft.Json;
 using Notify.Functions.Core;
-using Notify.Functions.HTTPClients;
 using Notify.Functions.Utils;
 using MongoUtils = Notify.Functions.Utils.MongoUtils;
 
@@ -46,7 +42,7 @@ namespace Notify.Functions.NotifyFunctions.Friend
             }
             else
             {
-                message = $"Friendship between {username} and {friendName} was deleted";
+                message = $"Friendship and permissions between {username} and {friendName} was deleted";
                 result = new OkObjectResult(message);
             }
             
@@ -62,8 +58,29 @@ namespace Notify.Functions.NotifyFunctions.Friend
                     Builders<BsonDocument>.Filter.Eq("userName2", friendName)),
                 Builders<BsonDocument>.Filter.And(Builders<BsonDocument>.Filter.Eq("userName1", friendName),
                     Builders<BsonDocument>.Filter.Eq("userName2", username)));
+            DeleteResult friendshipDeleteResult = await collection.DeleteOneAsync(filter);
+            DeleteResult permissionDeleteResult = null;
             
-            return await collection.DeleteOneAsync(filter);
+            if (!friendshipDeleteResult.DeletedCount.Equals(0))
+            {
+                permissionDeleteResult = await deletePermissionsFromDatabase(username, friendName);
+            }
+            
+            return permissionDeleteResult ?? friendshipDeleteResult;
+        }
+
+        private static async Task<DeleteResult> deletePermissionsFromDatabase(string username, string friendName)
+        {
+            FilterDefinition<BsonDocument> filter;
+            IMongoCollection<BsonDocument> permissionsCollection = MongoUtils.GetCollection(Constants.COLLECTION_PERMISSION);
+            filter = Builders<BsonDocument>.Filter.Or(
+                Builders<BsonDocument>.Filter.And(Builders<BsonDocument>.Filter.Eq("permit", username),
+                    Builders<BsonDocument>.Filter.Eq("username", friendName)),
+                Builders<BsonDocument>.Filter.And(Builders<BsonDocument>.Filter.Eq("permit", friendName),
+                    Builders<BsonDocument>.Filter.Eq("username", username))
+            );
+
+            return await permissionsCollection.DeleteManyAsync(filter);
         }
     }
 }

--- a/Notify/Notify.Functions/Notify.Functions/NotifyFunctions/Notification/CreateNotification.cs
+++ b/Notify/Notify.Functions/Notify.Functions/NotifyFunctions/Notification/CreateNotification.cs
@@ -91,7 +91,7 @@ namespace Notify.Functions.NotifyFunctions.Notification
                     { "user", user }
                 };
 
-                if (type.ToLower().Equals(Constants.NOTIFICATION_TYPE_LOCATION.ToLower()))
+                if (type.ToLower().Equals(Constants.NOTIFICATION_TYPE_LOCATION_LOWER))
                 {
                     document["notification"]["activation"] = Convert.ToString(json["notification"]["activation"]);
                     document["notification"]["permanent"] = Convert.ToString(json["notification"]["permanent"]);
@@ -135,12 +135,12 @@ namespace Notify.Functions.NotifyFunctions.Notification
         {
             string lowerCasedType = type.ToLower();
             
-            if (lowerCasedType.Equals(Constants.NOTIFICATION_TYPE_LOCATION.ToLower())
-                || lowerCasedType.Equals(Constants.NOTIFICATION_TYPE_DYNAMIC.ToLower()))
+            if (lowerCasedType.Equals(Constants.NOTIFICATION_TYPE_LOCATION_LOWER)
+                || lowerCasedType.Equals(Constants.NOTIFICATION_TYPE_DYNAMIC_LOWER))
             {
                 extraElement = new BsonElement("location", json["notification"]["location"].ToString());
             }
-            else if(lowerCasedType.Equals(Constants.NOTIFICATION_TYPE_TIME.ToLower()))
+            else if(lowerCasedType.Equals(Constants.NOTIFICATION_TYPE_TIME_LOWER))
             {
                 extraElement = new BsonElement("timestamp", int.Parse(json["notification"]["timestamp"].ToString()));
             }

--- a/Notify/Notify.Functions/Notify.Functions/NotifyFunctions/Notification/GetNotifications.cs
+++ b/Notify/Notify.Functions/Notify.Functions/NotifyFunctions/Notification/GetNotifications.cs
@@ -10,7 +10,6 @@ using Microsoft.Extensions.Logging;
 using MongoDB.Bson;
 using MongoDB.Driver;
 using Notify.Functions.Core;
-using Notify.Functions.HTTPClients;
 using Notify.Functions.Utils;
 using MongoUtils = Notify.Functions.Utils.MongoUtils;
 

--- a/Notify/Notify.Functions/Notify.Functions/NotifyFunctions/Notification/UpdateNotification.cs
+++ b/Notify/Notify.Functions/Notify.Functions/NotifyFunctions/Notification/UpdateNotification.cs
@@ -56,17 +56,17 @@ namespace Notify.Functions.NotifyFunctions.Notification
             updates.Add(updateBuilder.Set("notification.name", Convert.ToString(data.name)));
             updates.Add(updateBuilder.Set("description", Convert.ToString(data.description)));
 
-            if (lowerCasedType.Equals("location"))
+            if (lowerCasedType.Equals(Constants.NOTIFICATION_TYPE_LOCATION_LOWER))
             {
                 updates.Add(updateBuilder.Set("notification.location", Convert.ToString(data.location)));
                 updates.Add(updateBuilder.Set("notification.permanent", Convert.ToString(data.permanent)));
                 updates.Add(updateBuilder.Set("notification.location", Convert.ToString(data.location)));
             }
-            else if (lowerCasedType.Equals("dynamic"))
+            else if (lowerCasedType.Equals(Constants.NOTIFICATION_TYPE_DYNAMIC_LOWER))
             {
                 updates.Add(updateBuilder.Set("notification.location", Convert.ToString(data.location)));
             }
-            else if (lowerCasedType.Equals("time"))
+            else if (lowerCasedType.Equals(Constants.NOTIFICATION_TYPE_TIME_LOWER))
             {
                 updates.Add(updateBuilder.Set("notification.timestamp", Convert.ToInt64(data.timestamp)));
             }
@@ -92,7 +92,7 @@ namespace Notify.Functions.NotifyFunctions.Notification
             {
                 throw new ArgumentException($"Notification with id {data.id} is not a type of '{lowerCasedType}'");
             }
-            if(!lowerCasedType.Equals("location"))
+            if(!lowerCasedType.Equals(Constants.NOTIFICATION_TYPE_LOCATION_LOWER))
             {
                 if (data.permanent != null && Convert.ToBoolean(data.permanent))
                 {

--- a/Notify/Notify.Functions/Notify.Functions/NotifyFunctions/Permission/GetPermissions.cs
+++ b/Notify/Notify.Functions/Notify.Functions/NotifyFunctions/Permission/GetPermissions.cs
@@ -1,0 +1,68 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Azure.WebJobs;
+using Microsoft.Azure.WebJobs.Extensions.Http;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Azure.WebJobs.Host;
+using Microsoft.Extensions.Logging;
+using MongoDB.Bson;
+using MongoDB.Driver;
+using Newtonsoft.Json;
+using Notify.Functions.Core;
+using Notify.Functions.Utils;
+using MongoUtils = Notify.Functions.Utils.MongoUtils;
+
+namespace Notify.Functions.NotifyFunctions.Permission
+{
+    public static class GetPermissions
+    {
+        [FunctionName("GetPermissions")]
+        [AllowAnonymous]
+        public static async Task<IActionResult> RunAsync(
+            [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "permission")]
+            HttpRequest req, ILogger logger)
+        {
+            string lowerCasedUsername;
+            List<BsonDocument> documents;
+            ActionResult result;
+            
+            if (!ValidationUtils.ValidateUsername(req, logger))
+            {
+                result = new BadRequestObjectResult("Invalid username provided");
+            }
+            else
+            {
+                lowerCasedUsername = req.Query["username"].ToString().ToLower();
+                documents = await getPermissionDocumentsAsync(lowerCasedUsername, logger);
+
+                if (documents.Count.Equals(0))
+                {
+                    logger.LogError($"No permissions found for {lowerCasedUsername}");
+                    result = new NotFoundObjectResult($"No permissions found for {lowerCasedUsername}");
+                }
+                else
+                {
+                    logger.LogInformation($"Found {documents.Count} permission documents for {lowerCasedUsername}");
+                    result = new OkObjectResult(ConversionUtils.ConvertBsonDocumentListToJson(documents));
+                }
+            }
+
+            return result;
+        }
+        
+        private static async Task<List<BsonDocument>> getPermissionDocumentsAsync(string lowerCasedUsername, ILogger logger)
+        {
+            IMongoCollection<BsonDocument> collection = MongoUtils.GetCollection(Constants.COLLECTION_PERMISSION);
+            FilterDefinition<BsonDocument> filter = Builders<BsonDocument>.Filter
+                .Where(doc => doc["permit"].ToString().ToLower().Equals(lowerCasedUsername));
+
+            logger.LogInformation($"Getting permissions for {lowerCasedUsername}");
+
+            return await collection.Find(filter).ToListAsync();
+        }
+    }
+}

--- a/Notify/Notify.Functions/Notify.Functions/NotifyFunctions/Permission/GetPermissions.cs
+++ b/Notify/Notify.Functions/Notify.Functions/NotifyFunctions/Permission/GetPermissions.cs
@@ -1,17 +1,13 @@
-using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Azure.WebJobs;
 using Microsoft.Azure.WebJobs.Extensions.Http;
 using Microsoft.AspNetCore.Http;
-using Microsoft.Azure.WebJobs.Host;
 using Microsoft.Extensions.Logging;
 using MongoDB.Bson;
 using MongoDB.Driver;
-using Newtonsoft.Json;
 using Notify.Functions.Core;
 using Notify.Functions.Utils;
 using MongoUtils = Notify.Functions.Utils.MongoUtils;

--- a/Notify/Notify.Functions/Notify.Functions/NotifyFunctions/Permission/UpdatePermission.cs
+++ b/Notify/Notify.Functions/Notify.Functions/NotifyFunctions/Permission/UpdatePermission.cs
@@ -1,0 +1,108 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Azure.WebJobs;
+using Microsoft.Azure.WebJobs.Extensions.Http;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging;
+using MongoDB.Bson;
+using MongoDB.Driver;
+using Notify.Functions.Core;
+using Notify.Functions.Utils;
+using MongoUtils = Notify.Functions.Utils.MongoUtils;
+
+namespace Notify.Functions.NotifyFunctions.Permission
+{
+    public static class UpdatePermission
+    {
+        [FunctionName("UpdatePermission")]
+        [AllowAnonymous]
+        public static async Task<IActionResult> RunAsync(
+            [HttpTrigger(AuthorizationLevel.Anonymous, "put", "post", Route = "permission")]
+            HttpRequest req, ILogger log)
+        {
+            dynamic data = await ConversionUtils.ExtractBodyContentAsync(req);
+            ActionResult result;
+
+            log.LogInformation($"Got client's HTTP request to update permission");
+
+            if (data.permit == null || data.username == null)
+            {
+                result = new BadRequestObjectResult("Invalid request body: permit and username are required");
+            }
+            else if (data.location == null && data.dynamic == null && data.time == null)
+            {
+                result = new BadRequestObjectResult("Invalid request body: location, dynamic or time are required");
+            }
+            else
+            {
+                result = await updatePermissionAsync(data, log);
+            }
+
+            return result;
+        }
+
+        private static async Task<ActionResult> updatePermissionAsync(dynamic data, ILogger log)
+        {
+            IMongoCollection<BsonDocument> collection = MongoUtils.GetCollection(Constants.COLLECTION_PERMISSION);
+            FilterDefinition<BsonDocument> filter = Builders<BsonDocument>.Filter.And(
+                Builders<BsonDocument>.Filter.Eq("permit", data.permit.ToString()),
+                Builders<BsonDocument>.Filter.Eq("username", data.username.ToString()));
+            BsonDocument permissionDocument = await collection.FindAsync(filter).Result.FirstOrDefaultAsync();
+            List<UpdateDefinition<BsonDocument>> updates;
+
+            if (permissionDocument == null)
+            {
+                string errorMessage = $"No permission found for {data.permit} and {data.username}";
+                log.LogError(errorMessage);
+                return new NotFoundObjectResult(errorMessage);
+            }
+
+            updates = CollectUpdates(data);
+            if (updates.Count == 0)
+            {
+                return new BadRequestObjectResult("No valid updates provided in request.");
+            }
+
+            await collection.UpdateOneAsync(filter, Builders<BsonDocument>.Update.Combine(updates));
+            return new OkObjectResult($"Permission for {data.permit} and {data.username} was updated");
+        }
+        
+        private static List<UpdateDefinition<BsonDocument>> CollectUpdates(dynamic data)
+        {
+            List<UpdateDefinition<BsonDocument>> updates = new List<UpdateDefinition<BsonDocument>>();
+            UpdateDefinitionBuilder<BsonDocument> updateBuilder = Builders<BsonDocument>.Update;
+
+            Dictionary<string, object> attributes = new Dictionary<string, object>
+            {
+                { Constants.NOTIFICATION_TYPE_LOCATION_LOWER, data.location },
+                { Constants.NOTIFICATION_TYPE_DYNAMIC_LOWER, data.dynamic },
+                { Constants.NOTIFICATION_TYPE_TIME_LOWER, data.time }
+            };
+
+            foreach (KeyValuePair<string, object> attribute in attributes)
+            {
+                if (attribute.Value != null)
+                {
+                    if (IsValidPermission(attribute.Value.ToString()))
+                    {
+                        updates.Add(updateBuilder.Set(attribute.Key, attribute.Value.ToString()));
+                    }
+                    else
+                    {
+                        throw new ArgumentException($"Invalid request body for {attribute.Key}: permission value must be either '{Constants.PERMISSION_ALLOW}' or '{Constants.PERMISSION_DISALLOW}'");
+                    }
+                }
+            }
+
+            return updates;
+        }
+
+        private static bool IsValidPermission(string permission)
+        {
+            return permission.Equals(Constants.PERMISSION_ALLOW) || permission.Equals(Constants.PERMISSION_DISALLOW);
+        }
+    }
+}

--- a/Notify/Notify.Functions/Notify.Functions/Utils/ConversionUtils.cs
+++ b/Notify/Notify.Functions/Notify.Functions/Utils/ConversionUtils.cs
@@ -15,7 +15,7 @@ namespace Notify.Functions.Utils
     {
         public static string ConvertBsonDocumentListToJson(List<BsonDocument> bsonDocumentList)
         {
-            JsonWriterSettings jsonSettings = new JsonWriterSettings { OutputMode = JsonOutputMode.Strict };
+            JsonWriterSettings jsonSettings = new JsonWriterSettings { OutputMode = JsonOutputMode.CanonicalExtendedJson };
             string jsonArrayString, id;
             JArray jsonArray;
 

--- a/Notify/Notify.Functions/Postman/Collections/Permission.postman_collection.json
+++ b/Notify/Notify.Functions/Postman/Collections/Permission.postman_collection.json
@@ -1,0 +1,60 @@
+{
+	"info": {
+		"_postman_id": "6be0d7c1-7208-4b4f-bb2f-1f1c50252ac5",
+		"name": "Permission",
+		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
+		"_exporter_id": "26136776",
+		"_collection_link": "https://warped-shadow-814178.postman.co/workspace/My-Workspace~54429c37-4045-4a7c-8a63-dc888dec1345/collection/26136776-6be0d7c1-7208-4b4f-bb2f-1f1c50252ac5?action=share&source=collection_link&creator=26136776"
+	},
+	"item": [
+		{
+			"name": "Get permissions",
+			"request": {
+				"method": "GET",
+				"header": [],
+				"url": {
+					"raw": "{{HTTP}}/permission?username=MaTaSaS",
+					"host": [
+						"{{HTTP}}"
+					],
+					"path": [
+						"permission"
+					],
+					"query": [
+						{
+							"key": "username",
+							"value": "MaTaSaS"
+						}
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "Get permissions Copy",
+			"request": {
+				"method": "POST",
+				"header": [],
+				"body": {
+					"mode": "raw",
+					"raw": "{\n    \"permit\": \"MaTaSaS\",\n    \"username\": \"linkimos\",\n    \"location\": \"Disallow\",\n    \"dynamic\": \"Allow\",\n    \"time\": \"Disallow\"\n}",
+					"options": {
+						"raw": {
+							"language": "json"
+						}
+					}
+				},
+				"url": {
+					"raw": "{{HTTP}}/permission",
+					"host": [
+						"{{HTTP}}"
+					],
+					"path": [
+						"permission"
+					]
+				}
+			},
+			"response": []
+		}
+	]
+}

--- a/Notify/Notify/Notify/Azure/HttpClient/AzureHttpClient.cs
+++ b/Notify/Notify/Notify/Azure/HttpClient/AzureHttpClient.cs
@@ -911,5 +911,48 @@ namespace Notify.Azure.HttpClient
 
             return isUpdated;
         }
+
+        public async Task<List<Permission>> GetFriendsPermissions()
+        {
+            return await GetData(
+                endpoint: Constants.AZURE_FUNCTIONS_PATTERN_PERMISSION,
+                preferencesKey: Constants.PREFERENCES_FRIENDS_PERMISSIONS, 
+                converter: Converter.ToPermission);
+        }
+
+        public async Task<bool> UpdateFriendPermissionsAsync(string friendUsername, string locationNotificationsPermission, string timeNotificationsPermission, string dynamicNotificationsPermission)
+        {
+            bool isUpdated;
+            string username = Preferences.Get(Constants.PREFERENCES_USERNAME, string.Empty);
+            dynamic data = new JObject
+            {
+                { "permit", username },
+                { "username", friendUsername },
+                { "location", locationNotificationsPermission },
+                { "time", timeNotificationsPermission },
+                { "dynamic", dynamicNotificationsPermission }
+            };
+            string json = JsonConvert.SerializeObject(data);
+            
+            r_Logger.LogInformation($"request:{Environment.NewLine}{json}");
+
+            try
+            {
+                HttpResponseMessage responseMessage = await postAsync(requestUri: Constants.AZURE_FUNCTIONS_PATTERN_PERMISSION, createJsonStringContent(json));
+                responseMessage.EnsureSuccessStatusCode();
+                
+                r_Logger.LogDebug($"Successful status code from Azure Function from UpdateFriendPermissionsAsync");
+                isUpdated = true;
+                
+                await GetFriendsPermissions();
+            }
+            catch (Exception ex)
+            {
+                r_Logger.LogError($"Error occured on UpdateFriendPermissionsAsync: {ex.Message}");
+                isUpdated = false;
+            }
+            
+            return isUpdated;
+        }
     }
 }

--- a/Notify/Notify/Notify/Core/Permission.cs
+++ b/Notify/Notify/Notify/Core/Permission.cs
@@ -1,0 +1,18 @@
+namespace Notify.Core
+{
+    public class Permission
+    {
+        public string FriendUsername { get; set; }
+        public string LocationNotificationPermission { get; set; }
+        public string TimeNotificationPermission { get; set; }
+        public string DynamicNotificationPermission { get; set; }
+        
+        public Permission(string friendUsername, string locationNotificationPermission, string timeNotificationPermission, string dynamicNotificationPermission)
+        {
+            FriendUsername = friendUsername;
+            LocationNotificationPermission = locationNotificationPermission;
+            TimeNotificationPermission = timeNotificationPermission;
+            DynamicNotificationPermission = dynamicNotificationPermission;
+        }
+    }
+}

--- a/Notify/Notify/Notify/Core/User.cs
+++ b/Notify/Notify/Notify/Core/User.cs
@@ -1,7 +1,5 @@
-using System;
 using System.ComponentModel;
 using System.Runtime.CompilerServices;
-using Xamarin.Forms;
 
 namespace Notify.Core
 {

--- a/Notify/Notify/Notify/Helpers/Constants.cs
+++ b/Notify/Notify/Notify/Helpers/Constants.cs
@@ -119,6 +119,9 @@ namespace Notify.Helpers
         public static readonly string NOTIFICATION_STATUS_DECLINED = "Declined";
         public static readonly string NOTIFICATION_STATUS_ARRIVED = "Arrived";
         public static readonly string NOTIFICATION_STATUS_EXPIRED = "Expired";
+        
+        public static readonly string NOTIFICATION_PERMISSION_ALLOW = "Allow";
+        public static readonly string NOTIFICATION_PERMISSION_DISALLOW = "Disallow";
 
         #endregion
 
@@ -143,6 +146,7 @@ namespace Notify.Helpers
         public static readonly string AZURE_FUNCTIONS_PATTERN_DESTINATION_UPDATE = AZURE_FUNCTIONS_PATTERN_DESTINATION + "/update";
         public static readonly string AZURE_FUNCTIONS_PATTERN_DESTINATION_SUGGESTIONS = AZURE_FUNCTIONS_PATTERN_DESTINATION + "/suggestions";
         public static readonly string AZURE_FUNCTIONS_PATTERN_DESTINATION_COORDINATES= AZURE_FUNCTIONS_PATTERN_DESTINATION + "/coordinates";
+        public static readonly string AZURE_FUNCTIONS_PATTERN_PERMISSION = "permission";
         public static readonly string AZURE_FUNCTIONS_PATTERN_LOGIN = "login";
         public static readonly string AZURE_FUNCTIONS_PATTERN_REGISTER = "register";
         public static readonly string AZURE_FUNCTIONS_PATTERN_FRIEND = "friend";
@@ -199,7 +203,7 @@ namespace Notify.Helpers
         public static readonly string PREFERENCES_USERNAME = "NotifyUserName";
         public static readonly string PREFERENCES_PASSWORD = "NotifyPassword";
         public static readonly string PREFERENCES_NOT_FRIENDS_USERS = "NotFriendsUsers";
-        public static readonly string PREFERENCES_DYNAMIC_LOCATIONS = "DynamicLocations";
+        public static readonly string PREFERENCES_FRIENDS_PERMISSIONS = "FriendsPermissions";
 
         #endregion
 

--- a/Notify/Notify/Notify/Helpers/Converter.cs
+++ b/Notify/Notify/Notify/Helpers/Converter.cs
@@ -90,5 +90,14 @@ namespace Notify.Helpers
                 Address = (string)(destination.location.address ?? "")
             };
         }
+        
+        public static Permission ToPermission(dynamic permission)
+        {
+            return new Permission(
+                friendUsername: (string)permission.username,
+                locationNotificationPermission: (string)permission.location,
+                timeNotificationPermission: (string)permission.time,
+                dynamicNotificationPermission: (string)permission.dynamic);
+        }
     }
 }

--- a/Notify/Notify/Notify/ViewModels/FriendDetailsPageViewModel.cs
+++ b/Notify/Notify/Notify/ViewModels/FriendDetailsPageViewModel.cs
@@ -2,8 +2,13 @@ using System.Collections.Generic;
 using System.ComponentModel;
 using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
+using Microsoft.IdentityModel.Tokens;
+using Notify.Azure.HttpClient;
 using Notify.Core;
+using Notify.Helpers;
+using Xamarin.Essentials;
 using Xamarin.Forms;
+using Newtonsoft.Json;
 
 namespace Notify.ViewModels
 {
@@ -13,21 +18,77 @@ namespace Notify.ViewModels
         public string UserName { get; set; }
         public string Telephone { get; set; }
         public ImageSource ProfileImage { get; set; }
-
+        public List<string> AllowDisallowOptions { get; set; } = new List<string> { Constants.NOTIFICATION_PERMISSION_ALLOW, Constants.NOTIFICATION_PERMISSION_DISALLOW };
         public Command BackCommand { get; set; }
+        public Command UpdateFriendPermissionsCommand { get; set; }
+        public string DynamicNotificationsPermission { get; set; }
+        public string LocationNotificationsPermission { get; set; }
+        public string TimeNotificationsPermission { get; set; }
         
         public FriendDetailsPageViewModel(User selectedFriend)
         {
             BackCommand = new Command(onBackButtonClicked);
+            UpdateFriendPermissionsCommand = new Command(onUpdateFriendPermissionsButtonClicked);
             Task.Run(() => setSelectedFriendDetails(selectedFriend));
         }
-        
+
+        private async void onUpdateFriendPermissionsButtonClicked()
+        {
+            bool isUpdated = await AzureHttpClient.Instance.UpdateFriendPermissionsAsync(UserName, LocationNotificationsPermission, TimeNotificationsPermission, DynamicNotificationsPermission);
+            
+            if(isUpdated)
+            {
+                await Shell.Current.DisplayAlert("Success", "Friend permissions updated successfully", "OK");
+            }
+            else
+            {
+                await Shell.Current.DisplayAlert("Error", "Failed to update friend permissions", "OK");
+            }
+        }
+
         private async void onBackButtonClicked()
         {
             await Shell.Current.Navigation.PopAsync();
         }
 
         private void setSelectedFriendDetails(User friend)
+        {
+            setSelectedFriendStaticDetails(friend);
+            setSelectedFriendPermissionsDetails(friend.UserName);
+        }
+
+        private async void setSelectedFriendPermissionsDetails(string friendUsername)
+        {
+            Permission currentFriendPermission;
+            List<Permission> allFriendsPermissions;
+            string friendPermissionsJson = Preferences.Get(Constants.PREFERENCES_FRIENDS_PERMISSIONS, string.Empty);
+
+            if (friendPermissionsJson.IsNullOrEmpty())
+            {
+                allFriendsPermissions = await AzureHttpClient.Instance.GetFriendsPermissions();
+            }
+            else 
+            {
+                allFriendsPermissions = JsonConvert.DeserializeObject<List<Permission>>(friendPermissionsJson);
+            }
+
+            currentFriendPermission = allFriendsPermissions.Find(permission => permission.FriendUsername.Equals(friendUsername));
+
+            if(currentFriendPermission == null)
+            {
+                LocationNotificationsPermission = Constants.NOTIFICATION_PERMISSION_DISALLOW;
+                TimeNotificationsPermission = Constants.NOTIFICATION_PERMISSION_DISALLOW;
+                DynamicNotificationsPermission = Constants.NOTIFICATION_PERMISSION_DISALLOW;
+            }
+            else
+            {
+                LocationNotificationsPermission = currentFriendPermission.LocationNotificationPermission;
+                TimeNotificationsPermission = currentFriendPermission.TimeNotificationPermission;
+                DynamicNotificationsPermission = currentFriendPermission.DynamicNotificationPermission;
+            }
+        }
+
+        private void setSelectedFriendStaticDetails(User friend)
         {
             Name = friend.Name;
             UserName = friend.UserName;

--- a/Notify/Notify/Notify/ViewModels/FriendDetailsPageViewModel.cs
+++ b/Notify/Notify/Notify/ViewModels/FriendDetailsPageViewModel.cs
@@ -18,7 +18,7 @@ namespace Notify.ViewModels
         public string UserName { get; set; }
         public string Telephone { get; set; }
         public ImageSource ProfileImage { get; set; }
-        public List<string> AllowDisallowOptions { get; set; } = new List<string> { Constants.NOTIFICATION_PERMISSION_ALLOW, Constants.NOTIFICATION_PERMISSION_DISALLOW };
+        public List<string> PermissionOptions { get; set; } = new List<string> { Constants.NOTIFICATION_PERMISSION_ALLOW, Constants.NOTIFICATION_PERMISSION_DISALLOW };
         public Command BackCommand { get; set; }
         public Command UpdateFriendPermissionsCommand { get; set; }
         public string DynamicNotificationsPermission { get; set; }

--- a/Notify/Notify/Notify/Views/SubViews/FriendDetailsPage.xaml
+++ b/Notify/Notify/Notify/Views/SubViews/FriendDetailsPage.xaml
@@ -109,7 +109,7 @@
                 <Picker
                     Grid.Column="1"
                     Grid.Row="3"
-                    ItemsSource="{Binding AllowDisallowOptions}"
+                    ItemsSource="{Binding PermissionOptions}"
                     SelectedItem="{Binding LocationNotificationsPermission}"
                     TextColor="{AppThemeBinding Light={StaticResource LightPrimaryTextColor},
                                                 Dark={StaticResource DarkPrimaryTextColor}}" />
@@ -127,7 +127,7 @@
                 <Picker
                     Grid.Column="1"
                     Grid.Row="4"
-                    ItemsSource="{Binding AllowDisallowOptions}"
+                    ItemsSource="{Binding PermissionOptions}"
                     SelectedItem="{Binding TimeNotificationsPermission}"
                     TextColor="{AppThemeBinding Light={StaticResource LightPrimaryTextColor},
                                                 Dark={StaticResource DarkPrimaryTextColor}}" />
@@ -145,7 +145,7 @@
                 <Picker
                     Grid.Column="1"
                     Grid.Row="5"
-                    ItemsSource="{Binding AllowDisallowOptions}"
+                    ItemsSource="{Binding PermissionOptions}"
                     SelectedItem="{Binding DynamicNotificationsPermission}"
                     TextColor="{AppThemeBinding Light={StaticResource LightPrimaryTextColor},
                                                 Dark={StaticResource DarkPrimaryTextColor}}" />

--- a/Notify/Notify/Notify/Views/SubViews/FriendDetailsPage.xaml
+++ b/Notify/Notify/Notify/Views/SubViews/FriendDetailsPage.xaml
@@ -15,29 +15,36 @@
                     HorizontalTextAlignment="Center"
                     Text="Friend Details"
                     TextColor="{AppThemeBinding Light={StaticResource LightPrimaryTextColor},
-                                                Dark={StaticResource DarkPrimaryTextColor}}" />
-                <Image
-                    Aspect="AspectFit"
+                                                Dark={StaticResource DarkPrimaryTextColor}}"
+                    VerticalTextAlignment="Center" />
+
+                <Button
+                    Background="Transparent"
+                    BackgroundColor="Transparent"
+                    Command="{Binding BackCommand}"
+                    FontAttributes="Bold"
+                    FontSize="30"
                     Grid.Column="0"
-                    HeightRequest="50"
+                    Grid.Row="0"
                     HorizontalOptions="Start"
-                    Source="back.png">
-                    <Image.GestureRecognizers>
-                        <TapGestureRecognizer Command="{Binding BackCommand}" />
-                    </Image.GestureRecognizers>
-                </Image>
+                    Text="❮"
+                    TextColor="{AppThemeBinding Light={StaticResource DarkButtonTextColor},
+                                                Dark={StaticResource LightEntryBackgroundColor}}"
+                    VerticalOptions="Start" />
+
             </Grid>
 
             <Grid
                 Column="3"
                 ColumnDefinitions="auto, auto, *"
-                RowDefinitions="auto, auto, auto">
+                Margin="20"
+                RowDefinitions="auto, auto, auto, auto, auto, auto, *, *">
                 <Label
                     FontAttributes="Bold"
                     FontSize="Medium"
                     Grid.Column="0"
                     Grid.Row="0"
-                    Margin="0,10,0,0"
+                    Margin="0,15,0,0"
                     Text="Name:"
                     TextColor="{AppThemeBinding Light={StaticResource LightPrimaryTextColor},
                                                 Dark={StaticResource DarkPrimaryTextColor}}" />
@@ -45,7 +52,7 @@
                     FontSize="Medium"
                     Grid.Column="1"
                     Grid.Row="0"
-                    Margin="0,10,0,0"
+                    Margin="0,15,0,0"
                     Text="{Binding Name}"
                     TextColor="{AppThemeBinding Light={StaticResource LightPrimaryTextColor},
                                                 Dark={StaticResource DarkPrimaryTextColor}}" />
@@ -54,7 +61,7 @@
                     FontSize="Medium"
                     Grid.Column="0"
                     Grid.Row="1"
-                    Margin="0,10,0,0"
+                    Margin="0,15,0,0"
                     Text="Username:"
                     TextColor="{AppThemeBinding Light={StaticResource LightPrimaryTextColor},
                                                 Dark={StaticResource DarkPrimaryTextColor}}" />
@@ -62,7 +69,7 @@
                     FontSize="Medium"
                     Grid.Column="1"
                     Grid.Row="1"
-                    Margin="0,10,0,0"
+                    Margin="0,15,0,0"
                     Text="{Binding UserName}"
                     TextColor="{AppThemeBinding Light={StaticResource LightPrimaryTextColor},
                                                 Dark={StaticResource DarkPrimaryTextColor}}" />
@@ -71,7 +78,7 @@
                     FontSize="Medium"
                     Grid.Column="0"
                     Grid.Row="2"
-                    Margin="0,10,0,0"
+                    Margin="0,15,0,0"
                     Text="Telephone:"
                     TextColor="{AppThemeBinding Light={StaticResource LightPrimaryTextColor},
                                                 Dark={StaticResource DarkPrimaryTextColor}}" />
@@ -79,7 +86,7 @@
                     FontSize="Medium"
                     Grid.Column="1"
                     Grid.Row="2"
-                    Margin="0,10,0,0"
+                    Margin="0,15,0,0"
                     Text="{Binding Telephone}"
                     TextColor="{AppThemeBinding Light={StaticResource LightPrimaryTextColor},
                                                 Dark={StaticResource DarkPrimaryTextColor}}" />
@@ -89,6 +96,74 @@
                     Grid.RowSpan="3"
                     HeightRequest="100"
                     Source="{Binding ProfileImage}" />
+
+                <Label
+                    FontAttributes="Bold"
+                    FontSize="Medium"
+                    Grid.Column="0"
+                    Grid.Row="3"
+                    Margin="0,15,0,0"
+                    Text="Location:"
+                    TextColor="{AppThemeBinding Light={StaticResource LightPrimaryTextColor},
+                                                Dark={StaticResource DarkPrimaryTextColor}}" />
+                <Picker
+                    Grid.Column="1"
+                    Grid.Row="3"
+                    ItemsSource="{Binding AllowDisallowOptions}"
+                    SelectedItem="{Binding LocationNotificationsPermission}"
+                    TextColor="{AppThemeBinding Light={StaticResource LightPrimaryTextColor},
+                                                Dark={StaticResource DarkPrimaryTextColor}}" />
+
+                <Label
+                    FontAttributes="Bold"
+                    FontSize="Medium"
+                    Grid.Column="0"
+                    Grid.Row="4"
+                    Margin="0,15,0,0"
+                    Text="Time:"
+                    TextColor="{AppThemeBinding Light={StaticResource LightPrimaryTextColor},
+                                                Dark={StaticResource DarkPrimaryTextColor}}" />
+
+                <Picker
+                    Grid.Column="1"
+                    Grid.Row="4"
+                    ItemsSource="{Binding AllowDisallowOptions}"
+                    SelectedItem="{Binding TimeNotificationsPermission}"
+                    TextColor="{AppThemeBinding Light={StaticResource LightPrimaryTextColor},
+                                                Dark={StaticResource DarkPrimaryTextColor}}" />
+
+                <Label
+                    FontAttributes="Bold"
+                    FontSize="Medium"
+                    Grid.Column="0"
+                    Grid.Row="5"
+                    Margin="0,15,0,0"
+                    Text="Dynamic:"
+                    TextColor="{AppThemeBinding Light={StaticResource LightPrimaryTextColor},
+                                                Dark={StaticResource DarkPrimaryTextColor}}" />
+
+                <Picker
+                    Grid.Column="1"
+                    Grid.Row="5"
+                    ItemsSource="{Binding AllowDisallowOptions}"
+                    SelectedItem="{Binding DynamicNotificationsPermission}"
+                    TextColor="{AppThemeBinding Light={StaticResource LightPrimaryTextColor},
+                                                Dark={StaticResource DarkPrimaryTextColor}}" />
+
+                <Button
+                    BackgroundColor="{AppThemeBinding Light={StaticResource LightButtonColor},
+                                                      Dark={StaticResource DarkButtonColor}}"
+                    Command="{Binding UpdateFriendPermissionsCommand}"
+                    CornerRadius="50"
+                    Grid.Column="0"
+                    Grid.ColumnSpan="3"
+                    Grid.Row="7"
+                    Margin="20"
+                    Style="{StaticResource Button_ExoRegular}"
+                    Text="Update"
+                    TextColor="{AppThemeBinding Light={StaticResource LightButtonTextColor},
+                                                Dark={StaticResource DarkButtonTextColor}}"
+                    VerticalOptions="EndAndExpand" />
             </Grid>
 
         </StackLayout>

--- a/Notify/Notify/Notify/Views/SubViews/NotificationDetailsPage.xaml
+++ b/Notify/Notify/Notify/Views/SubViews/NotificationDetailsPage.xaml
@@ -223,6 +223,49 @@
                     Text="{Binding Target}"
                     TextColor="{AppThemeBinding Light={StaticResource LightPrimaryTextColor},
                                                 Dark={StaticResource DarkPrimaryTextColor}}" />
+                <ImageButton
+                    BackgroundColor="Transparent"
+                    Command="{Binding AcceptNotificationCommand}"
+                    Grid.Column="1"
+                    Grid.Row="11"
+                    HeightRequest="50"
+                    Margin="0,20"
+                    VerticalOptions="End"
+                    WidthRequest="50">
+                    <ImageButton.Source>
+                        <FileImageSource File="accept_button.png" />
+                    </ImageButton.Source>
+                    <ImageButton.Triggers>
+                        <DataTrigger
+                            Binding="{Binding IsPending}"
+                            TargetType="ImageButton"
+                            Value="False">
+                            <Setter Property="IsVisible" Value="False" />
+                        </DataTrigger>
+                    </ImageButton.Triggers>
+                </ImageButton>
+
+                <ImageButton
+                    BackgroundColor="Transparent"
+                    Command="{Binding DeclineNotificationCommand}"
+                    Grid.Column="4"
+                    Grid.Row="11"
+                    HeightRequest="50"
+                    Margin="0,20"
+                    VerticalOptions="End"
+                    WidthRequest="50">
+                    <ImageButton.Source>
+                        <FileImageSource File="reject_button.png" />
+                    </ImageButton.Source>
+                    <ImageButton.Triggers>
+                        <DataTrigger
+                            Binding="{Binding IsPending}"
+                            TargetType="ImageButton"
+                            Value="False">
+                            <Setter Property="IsVisible" Value="False" />
+                        </DataTrigger>
+                    </ImageButton.Triggers>
+                </ImageButton>
 
                 <ImageButton
                     BackgroundColor="Transparent"
@@ -243,6 +286,12 @@
                             TargetType="ImageButton"
                             Value="False">
                             <Setter Property="Source" Value="delete_button_disabled.png" />
+                        </DataTrigger>
+                        <DataTrigger
+                            Binding="{Binding IsPending}"
+                            TargetType="ImageButton"
+                            Value="True">
+                            <Setter Property="IsVisible" Value="False" />
                         </DataTrigger>
                     </ImageButton.Triggers>
                 </ImageButton>
@@ -267,6 +316,12 @@
                             Value="False">
                             <Setter Property="Source" Value="edit_button_disabled.png" />
                         </DataTrigger>
+                        <DataTrigger
+                            Binding="{Binding IsPending}"
+                            TargetType="ImageButton"
+                            Value="True">
+                            <Setter Property="IsVisible" Value="False" />
+                        </DataTrigger>
                     </ImageButton.Triggers>
                 </ImageButton>
 
@@ -289,6 +344,12 @@
                             TargetType="ImageButton"
                             Value="False">
                             <Setter Property="Source" Value="renew_button_disabled.png" />
+                        </DataTrigger>
+                        <DataTrigger
+                            Binding="{Binding IsPending}"
+                            TargetType="ImageButton"
+                            Value="True">
+                            <Setter Property="IsVisible" Value="False" />
                         </DataTrigger>
                     </ImageButton.Triggers>
                 </ImageButton>


### PR DESCRIPTION
## Description: 
Adding the ability to control over the permissions of every friend for creating notifications.
If the friend has the permission to do so, the notification's status will be initialized to "Active". If not - "Pending".

## Type of change:
- [ ] Bug fix
- [x] New feature
- [ ] Fix/new infrastructure

## Background context of the changes:
The user should have the option to choose which friends can automatically create location, time and/or dynamic notifications without waiting for being approved by the user.

## The ticket this PR closes:
[NOTIFY-182](https://ofirlindekel.atlassian.net/browse/NOTIFY-182)

## Scenarios that were tested during this implementation:
- The friend have permission to create a notification for the user (any type).
- The friend doesn't have permission to automatically create a notification for the user. 

## Insert screenshots / video of test results (for all relevant platforms)
https://github.com/OfirMatasas/Notify/assets/88926592/6597819d-1e29-40b9-acae-c531394c0bb0