### PR TITLE
Add profile picture for each friend

### DIFF
--- a/Notify/Notify.Functions/Notify.Functions/NotifyFunctions/Users/GetNotFriendUsers.cs
+++ b/Notify/Notify.Functions/Notify.Functions/NotifyFunctions/Users/GetNotFriendUsers.cs
@@ -1,7 +1,5 @@
-using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;

--- a/Notify/Notify.Functions/Notify.Functions/NotifyFunctions/Users/GetUserByUserName.cs
+++ b/Notify/Notify.Functions/Notify.Functions/NotifyFunctions/Users/GetUserByUserName.cs
@@ -9,7 +9,6 @@ using Microsoft.Extensions.Logging;
 using MongoDB.Bson;
 using MongoDB.Driver;
 using Notify.Functions.Core;
-using Notify.Functions.HTTPClients;
 using MongoUtils = Notify.Functions.Utils.MongoUtils;
 
 namespace Notify.Functions.NotifyFunctions.Users

--- a/Notify/Notify/Notify/Core/User.cs
+++ b/Notify/Notify/Notify/Core/User.cs
@@ -17,13 +17,13 @@ namespace Notify.Core
 
         #region Constructor
 
-        public User(string name, string username, string telephone)
+        public User(string name, string username, string telephone, string profilePicture)
         {
             Name = name;
             UserName = username;
             Telephone = telephone;
             IsSelected = false;
-            ProfilePicture = string.Empty;
+            ProfilePicture = profilePicture;
         }
 
         #endregion

--- a/Notify/Notify/Notify/Helpers/Constants.cs
+++ b/Notify/Notify/Notify/Helpers/Constants.cs
@@ -156,6 +156,7 @@ namespace Notify.Helpers
         public static readonly string AZURE_FUNCTIONS_PATTERN_REJECT_FRIEND_REQUEST = AZURE_FUNCTIONS_PATTERN_FRIEND + "/reject";
         public static readonly string AZURE_FUNCTIONS_PATTERN_ACCEPT_FRIEND_REQUEST = AZURE_FUNCTIONS_PATTERN_FRIEND + "/accept";
         public static readonly string AZURE_FUNCTIONS_PATTERN_UPLOAD_PROFILE_PICTURE_TO_BLOB = "uploadProfilePicture";
+        public static readonly string AZURE_FUNCTIONS_DEFAULT_USER_PROFILE_PICTURE = "https://notifyblobstorage.blob.core.windows.net/notifycontainer/4199b89b-48e4-477c-9496-50c340ccd882.jpg";
 
         #endregion
 
@@ -204,6 +205,7 @@ namespace Notify.Helpers
         public static readonly string PREFERENCES_PASSWORD = "NotifyPassword";
         public static readonly string PREFERENCES_NOT_FRIENDS_USERS = "NotFriendsUsers";
         public static readonly string PREFERENCES_FRIENDS_PERMISSIONS = "FriendsPermissions";
+        public static readonly string PREFERENCES_USER_OBJECT = "UserObject";
 
         #endregion
 

--- a/Notify/Notify/Notify/Helpers/Converter.cs
+++ b/Notify/Notify/Notify/Helpers/Converter.cs
@@ -150,10 +150,13 @@ namespace Notify.Helpers
         
         public static User ToFriend(dynamic friend)
         {
+            string profilePicture = friend.profilePicture ?? Constants.AZURE_FUNCTIONS_DEFAULT_USER_PROFILE_PICTURE;
+            
             return new User(
                 name: (string)friend.name, 
                 username: (string)friend.userName, 
-                telephone: (string)friend.telephone);
+                telephone: (string)friend.telephone,
+                profilePicture: profilePicture);
         }
         
         public static Destination ToDestination(dynamic destination)

--- a/Notify/Notify/Notify/ViewModels/NotificationCreationViewModel.cs
+++ b/Notify/Notify/Notify/ViewModels/NotificationCreationViewModel.cs
@@ -261,8 +261,10 @@ namespace Notify.ViewModels
             {
                 Friends = JsonConvert.DeserializeObject<List<User>>(friendsJson);
             }
-
-            Friends.Add(new User(string.Empty, myUsername, string.Empty));
+            
+            string loggedUserJson = Preferences.Get(Constants.PREFERENCES_USERNAME, string.Empty);
+            User loggedUser = JsonConvert.DeserializeObject<User>(loggedUserJson);
+            Friends.Add(new User(loggedUser.Name, myUsername, loggedUser.Telephone, loggedUser.ProfilePicture));
             Friends.Sort((friend1, friend2) => string.Compare(friend1.Name, friend2.Name, StringComparison.Ordinal));
         }
 

--- a/Notify/Notify/Notify/Views/FriendsPage.xaml
+++ b/Notify/Notify/Notify/Views/FriendsPage.xaml
@@ -64,16 +64,19 @@
                 <CollectionView.ItemTemplate>
                     <DataTemplate>
                         <Grid
-                            Column="3"
+                            Column="2"
                             ColumnDefinitions="*, *"
                             HorizontalOptions="Center"
                             RowDefinitions="auto">
-                            <Image
+                            <ImageButton
+                                Background="Transparent"
+                                CornerRadius="50"
                                 Grid.Column="0"
-                                HeightRequest="30"
+                                HeightRequest="50"
                                 HorizontalOptions="Center"
-                                Source="{Binding ProfileImage}"
-                                VerticalOptions="Center" />
+                                Source="{Binding ProfilePicture}"
+                                VerticalOptions="Center"
+                                WidthRequest="50" />
                             <Label
                                 FontSize="15"
                                 Grid.Column="1"


### PR DESCRIPTION
## Description: 
For each friend, their profile picture will be presented on the FriendsPage and on FriendDetailsPage.
If the friend doesn't have a profile picture, a default one will be presented.
Plus, the information of the logged in user will be saved on preferences.

## Type of change:
- [ ] Bug fix
- [x] New feature
- [ ] Fix/new infrastructure

## The ticket this PR closes:
[NOTIFY-186](https://ofirlindekel.atlassian.net/browse/NOTIFY-186)

## Scenarios that were tested during this implementation:
- The friend has a customized profile picture.
- The friend doesn't has a customized profile picture.

## Insert screenshots / video of test results (for all relevant platforms)
<img width="507" alt="image" src="https://github.com/OfirMatasas/Notify/assets/88926592/0a2dd9bf-b2f3-45f7-a897-3696853ca3cc">
<img width="506" alt="image" src="https://github.com/OfirMatasas/Notify/assets/88926592/2703681c-94c7-467c-8181-00f446b8f36e">
<img width="506" alt="image" src="https://github.com/OfirMatasas/Notify/assets/88926592/371a4eaa-c89e-403a-98cc-02413f636468">