### PR TITLE
Turn pending time notifications to expired

### DIFF
--- a/Notify/Notify/Notify.Android/Managers/AndroidWiFiManager.cs
+++ b/Notify/Notify/Notify.Android/Managers/AndroidWiFiManager.cs
@@ -89,8 +89,8 @@ namespace Notify.Droid.Managers
                 else
                 {
                     sendNotificationsForLeaveDestinations(notifications, destinations, ref sentNotifications, ref permanentNotifications);
-                    Utils.updateNotificationsStatus(sentNotifications, Constants.NOTIFICATION_STATUS_EXPIRED);
-                    Utils.updateNotificationsStatus(permanentNotifications, Constants.NOTIFICATION_STATUS_ACTIVE);
+                    Utils.UpdateNotificationsStatus(sentNotifications, Constants.NOTIFICATION_STATUS_EXPIRED);
+                    Utils.UpdateNotificationsStatus(permanentNotifications, Constants.NOTIFICATION_STATUS_ACTIVE);
                 }
             }
         }
@@ -123,9 +123,9 @@ namespace Notify.Droid.Managers
 
                 r_Logger.LogInformation("Finished sending Wi-Fi notifications");
                 
-                Utils.updateNotificationsStatus(sentNotifications, Constants.NOTIFICATION_STATUS_EXPIRED);
-                Utils.updateNotificationsStatus(arrivedNotifications, Constants.NOTIFICATION_STATUS_ARRIVED);
-                Utils.updateNotificationsStatus(permanentNotifications, Constants.NOTIFICATION_STATUS_ACTIVE);
+                Utils.UpdateNotificationsStatus(sentNotifications, Constants.NOTIFICATION_STATUS_EXPIRED);
+                Utils.UpdateNotificationsStatus(arrivedNotifications, Constants.NOTIFICATION_STATUS_ARRIVED);
+                Utils.UpdateNotificationsStatus(permanentNotifications, Constants.NOTIFICATION_STATUS_ACTIVE);
             }
         }
         

--- a/Notify/Notify/Notify/AppShell.xaml.cs
+++ b/Notify/Notify/Notify/AppShell.xaml.cs
@@ -152,6 +152,8 @@ namespace Notify
 
         private void sendAllRelevantLocationNotifications(Location location)
         {
+            string notificationsJson = Preferences.Get(Constants.PREFERENCES_NOTIFICATIONS, string.Empty);
+            List<Notification> notifications = JsonConvert.DeserializeObject<List<Notification>>(notificationsJson);
             List<Notification> sentNotifications = new List<Notification>();
             List<Notification> arrivedNotifications = new List<Notification>();
             List<Notification> permanentNotifications = new List<Notification>();
@@ -161,6 +163,7 @@ namespace Notify
                 getAllNotificationsForArrivalDestinations(location, ref sentNotifications, ref arrivedNotifications);
                 getAllNotificationsForLeaveDestinations(location, ref sentNotifications, ref permanentNotifications);
                 getAllNotificationsForElapsedTime(ref sentNotifications);
+                Utils.CheckForExpiredPendingTimeNotifications(notifications);
 
                 updateStatusOfNotifications(Constants.NOTIFICATION_STATUS_EXPIRED, sentNotifications);
                 updateStatusOfNotifications(Constants.NOTIFICATION_STATUS_ARRIVED, arrivedNotifications);

--- a/Notify/Notify/Notify/Azure/HttpClient/AzureHttpClient.cs
+++ b/Notify/Notify/Notify/Azure/HttpClient/AzureHttpClient.cs
@@ -397,6 +397,7 @@ namespace Notify.Azure.HttpClient
                 preferencesKey: Constants.PREFERENCES_NOTIFICATIONS, 
                 converter: Converter.ToNotification);
 
+            Utils.CheckForExpiredPendingTimeNotifications(notifications);
             createNewDynamicDestinations(notifications);
             DependencyService.Get<IWiFiManager>().SendNotifications(null, null);
 

--- a/Notify/Notify/Notify/Azure/HttpClient/AzureHttpClient.cs
+++ b/Notify/Notify/Notify/Azure/HttpClient/AzureHttpClient.cs
@@ -814,6 +814,8 @@ namespace Notify.Azure.HttpClient
                 { "id", notificationID }
             };
             
+            r_Logger.LogInformation($"request:{Environment.NewLine}{data}");
+            
             try
             {
                 response = await deleteAsync(

--- a/Notify/Notify/Notify/Bluetooth/BluetoothManager.cs
+++ b/Notify/Notify/Notify/Bluetooth/BluetoothManager.cs
@@ -111,8 +111,8 @@ namespace Notify.Bluetooth
 
                 sendNotificationsForLeaveDestinations(notifications, destinations, ref sentNotifications, ref permanentNotifications);
                 
-                Utils.updateNotificationsStatus(sentNotifications, Constants.NOTIFICATION_STATUS_EXPIRED);
-                Utils.updateNotificationsStatus(permanentNotifications, Constants.NOTIFICATION_STATUS_ACTIVE);
+                Utils.UpdateNotificationsStatus(sentNotifications, Constants.NOTIFICATION_STATUS_EXPIRED);
+                Utils.UpdateNotificationsStatus(permanentNotifications, Constants.NOTIFICATION_STATUS_ACTIVE);
             }
         }
 
@@ -194,9 +194,9 @@ namespace Notify.Bluetooth
                 
                 r_Logger.LogInformation("Finished sending bluetooth notifications");
 
-                Utils.updateNotificationsStatus(sentNotifications, Constants.NOTIFICATION_STATUS_EXPIRED);
-                Utils.updateNotificationsStatus(arrivedNotifications, Constants.NOTIFICATION_STATUS_ARRIVED);
-                Utils.updateNotificationsStatus(permanentNotifications, Constants.NOTIFICATION_STATUS_ACTIVE);
+                Utils.UpdateNotificationsStatus(sentNotifications, Constants.NOTIFICATION_STATUS_EXPIRED);
+                Utils.UpdateNotificationsStatus(arrivedNotifications, Constants.NOTIFICATION_STATUS_ARRIVED);
+                Utils.UpdateNotificationsStatus(permanentNotifications, Constants.NOTIFICATION_STATUS_ACTIVE);
             }
         }
 

--- a/Notify/Notify/Notify/ViewModels/NotificationsPageViewModel.cs
+++ b/Notify/Notify/Notify/ViewModels/NotificationsPageViewModel.cs
@@ -266,7 +266,7 @@ namespace Notify.ViewModels
         {
             string messageTitle = "Notification Acceptance";
             string messageBody = "Notification accepted successfully";
-            bool isConfirmed;
+            bool isConfirmed, isSucceeded;
             Notification notification;
 
             isConfirmed = await App.Current.MainPage.DisplayAlert(messageTitle,
@@ -277,12 +277,19 @@ namespace Notify.ViewModels
             {
                 notification = new Notification(notificationID);
 
-                AzureHttpClient.Instance.UpdateNotificationsStatus(
+                isSucceeded = AzureHttpClient.Instance.UpdateNotificationsStatus(
                     new List<Notification> { notification },
                     Constants.NOTIFICATION_STATUS_ACTIVE
                 );
 
-                OnNotificationsRefreshClicked();
+                if (isSucceeded)
+                {
+                    OnNotificationsRefreshClicked();
+                }
+                else
+                {
+                    messageBody = "Failed to accept notification";
+                }
                 
                 await App.Current.MainPage.DisplayAlert(messageTitle, messageBody, "OK");
             }

--- a/Notify/Notify/Notify/ViewModels/Popups/EditFriendPopupPage.cs
+++ b/Notify/Notify/Notify/ViewModels/Popups/EditFriendPopupPage.cs
@@ -12,13 +12,10 @@ namespace Notify.ViewModels.Popups
         
         public EditFriendPopupPage(string currentLocation, string currentTime, string currentDynamic)
         {
-            Label titleLabel;
+            Label titleLabel, locationLabel, timeLabel, dynamicLabel;
             Button updatePermissionsButton;
-            Frame locationFrame;
-            Frame timeFrame;
-            Frame dynamicFrame;
+            Frame locationFrame, timeFrame, dynamicFrame, frame;
             StackLayout stackLayout;
-            Frame frame;
             
             LocationPermissionPicker = CreatePicker("Location");
             TimePermissionPicker = CreatePicker("Time");  
@@ -34,7 +31,38 @@ namespace Notify.ViewModels.Popups
                 FontSize = 24,
                 FontAttributes = FontAttributes.Bold,
                 VerticalOptions = LayoutOptions.Center,
-                HorizontalOptions = LayoutOptions.Center
+                HorizontalOptions = LayoutOptions.Center,
+                TextColor = Color.Black
+            };
+
+            locationLabel = new Label
+            {
+                Text = "Location",
+                FontSize = 18,
+                FontAttributes = FontAttributes.Bold,
+                VerticalOptions = LayoutOptions.Center,
+                HorizontalOptions = LayoutOptions.Center,
+                TextColor = Color.Black
+            };
+            
+            timeLabel = new Label
+            {
+                Text = "Time",
+                FontSize = 18,
+                FontAttributes = FontAttributes.Bold,
+                VerticalOptions = LayoutOptions.Center,
+                HorizontalOptions = LayoutOptions.Center,
+                TextColor = Color.Black
+            };
+            
+            dynamicLabel = new Label
+            {
+                Text = "Dynamic",
+                FontSize = 18,
+                FontAttributes = FontAttributes.Bold,
+                VerticalOptions = LayoutOptions.Center,
+                HorizontalOptions = LayoutOptions.Center,
+                TextColor = Color.Black
             };
 
             updatePermissionsButton = new Button
@@ -46,22 +74,25 @@ namespace Notify.ViewModels.Popups
             
             updatePermissionsButton.Clicked += UpdatePermissionsButton_Clicked;
 
-            locationFrame = new Frame { Content = LocationPermissionPicker, CornerRadius = 5, Padding = 10, BackgroundColor = Color.LightGray };
-            timeFrame = new Frame { Content = TimePermissionPicker, CornerRadius = 5, Padding = 10, BackgroundColor = Color.LightGray };
-            dynamicFrame = new Frame { Content = DynamicPermissionPicker, CornerRadius = 5, Padding = 10, BackgroundColor = Color.LightGray };
+            locationFrame = new Frame { Content = LocationPermissionPicker, CornerRadius = 5, Padding = 5, BackgroundColor = Color.LightGray };
+            timeFrame = new Frame { Content = TimePermissionPicker, CornerRadius = 5, Padding = 5, BackgroundColor = Color.LightGray };
+            dynamicFrame = new Frame { Content = DynamicPermissionPicker, CornerRadius = 5, Padding = 5, BackgroundColor = Color.LightGray };
 
             stackLayout = new StackLayout
             {
                 Children =
                 {
                     titleLabel,
+                    locationLabel,
                     locationFrame,
+                    timeLabel,
                     timeFrame,
+                    dynamicLabel,
                     dynamicFrame,
                     updatePermissionsButton
                 },
-                Padding = new Thickness(20),
-                Spacing = 20
+                Padding = new Thickness(15),
+                Spacing = 15
             };
 
             frame = new Frame

--- a/Notify/Notify/Notify/Views/BluetoothSettingsPage.xaml
+++ b/Notify/Notify/Notify/Views/BluetoothSettingsPage.xaml
@@ -3,80 +3,80 @@
     NavigationPage.HasNavigationBar="False"
     x:Class="Notify.Views.BluetoothSettingsPage"
     xmlns="http://xamarin.com/schemas/2014/forms"
-    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
-    xmlns:materialDesignControls="clr-namespace:Plugin.MaterialDesignControls;assembly=Plugin.MaterialDesignControls">
+    xmlns:materialDesignControls="clr-namespace:Plugin.MaterialDesignControls;assembly=Plugin.MaterialDesignControls"
+    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml">
     <ContentPage.Content>
         <ScrollView>
 
             <Grid
                 BackgroundColor="{AppThemeBinding Light={StaticResource LightPageBackgroundColor},
                                                   Dark={StaticResource DarkPageBackgroundColor}}"
-                Row="9"
-                RowDefinitions="Auto, Auto, Auto, Auto, Auto, Auto, Auto, Auto, *">
-                
+                Row="6"
+                RowDefinitions="Auto, Auto, Auto, Auto, Auto, *">
+
                 <Button
-                    Grid.Row="0"
-                    Margin="-20, 0, 0, 0"
                     Background="Transparent"
                     BackgroundColor="Transparent"
                     Command="{Binding BackCommand}"
                     FontAttributes="Bold"
                     FontSize="30"
+                    Grid.Row="0"
                     HorizontalOptions="Start"
+                    Margin="-20,0,0,0"
                     Text="❮"
                     TextColor="{AppThemeBinding Light={StaticResource DarkButtonTextColor},
                                                 Dark={StaticResource LightEntryBackgroundColor}}"
                     VerticalOptions="Start" />
-                
+
                 <Label
-                    Grid.Row="1"
                     FontAttributes="Bold"
                     FontSize="30"
+                    Grid.Row="1"
                     HorizontalTextAlignment="Center"
                     Style="{StaticResource Body1FontSize_ExoBold}"
                     Text="Bluetooth Settings"
                     VerticalTextAlignment="Center" />
-                
-                <materialDesignControls:MaterialPicker
-                    Grid.Row="2"
-                    CornerRadius="10"
-                    LabelMargin="3"
-                    LabelSize="16"
-                    Margin="30,60,30,0"
-                    LabelText="Select Bluetooth"
-                    Placeholder="Select Bluetooth"
-                    LabelTextColor="Black"
-                    BackgroundColor="White"
-                    ItemsSource="{Binding BluetoothSelectionList}"
-                    SelectedItem="{Binding SelectedBluetoothID}"
-                    TabIndex="1"/>
 
                 <materialDesignControls:MaterialPicker
-                    Grid.Row="3"
+                    BackgroundColor="White"
                     CornerRadius="10"
+                    Grid.Row="2"
+                    ItemsSource="{Binding BluetoothSelectionList}"
                     LabelMargin="3"
                     LabelSize="16"
-                    Margin="30,20,30,0"
-                    LabelText="Select Location"
-                    Placeholder="Select Location"
+                    LabelText="Select Bluetooth"
                     LabelTextColor="Black"
+                    Margin="30,60,30,0"
+                    Placeholder="Select Bluetooth"
+                    SelectedItem="{Binding SelectedBluetoothID}"
+                    TabIndex="1" />
+
+                <materialDesignControls:MaterialPicker
                     BackgroundColor="White"
+                    CornerRadius="10"
+                    Grid.Row="3"
                     ItemsSource="{Binding LocationSelectionList}"
+                    LabelMargin="3"
+                    LabelSize="16"
+                    LabelText="Select Location"
+                    LabelTextColor="Black"
+                    Margin="30,20,30,0"
+                    Placeholder="Select Location"
                     SelectedItem="{Binding SelectedLocation}"
-                    TabIndex="1"/>
+                    TabIndex="1" />
 
                 <Button
-                    Grid.Row="9"
-                    Margin="50,80,50,180"
                     BackgroundColor="{AppThemeBinding Light={StaticResource LightButtonColor},
                                                       Dark={StaticResource DarkButtonColor}}"
                     Command="{Binding UpdateBluetoothSettingsCommand}"
                     CornerRadius="30"
+                    Grid.Row="4"
+                    Margin="50,80,50,180"
                     Text="UPDATE BLUETOOTH"
                     TextColor="{AppThemeBinding Light={StaticResource LightButtonTextColor},
                                                 Dark={StaticResource DarkButtonTextColor}}" />
             </Grid>
-                
+
         </ScrollView>
 
     </ContentPage.Content>

--- a/Notify/Notify/Notify/Views/LocationSettingsPage.xaml
+++ b/Notify/Notify/Notify/Views/LocationSettingsPage.xaml
@@ -5,7 +5,7 @@
     xmlns="http://xamarin.com/schemas/2014/forms"
     xmlns:materialDesignControls1="clr-namespace:Plugin.MaterialDesignControls;assembly=Plugin.MaterialDesignControls"
     xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml">
-    
+
     <ContentPage.Content>
         <ScrollView>
             <Grid
@@ -13,101 +13,100 @@
                                                   Dark={StaticResource DarkPageBackgroundColor}}"
                 Row="9"
                 RowDefinitions="Auto, Auto, Auto, Auto, Auto, Auto, Auto, Auto, *">
-              
+
                 <Button
-                    Grid.Row="0"
-                    Margin="-20, 0, 0, 0"
                     Background="Transparent"
                     BackgroundColor="Transparent"
                     Command="{Binding BackCommand}"
                     FontAttributes="Bold"
                     FontSize="25"
+                    Grid.Row="0"
                     HorizontalOptions="Start"
+                    Margin="-20,0,0,0"
                     Text="❮"
                     TextColor="{AppThemeBinding Light={StaticResource DarkButtonTextColor},
                                                 Dark={StaticResource LightEntryBackgroundColor}}"
                     VerticalOptions="Start" />
 
                 <Label
-                    Grid.Row="1"
                     FontAttributes="Bold"
                     FontSize="30"
+                    Grid.Row="1"
                     HorizontalTextAlignment="Center"
                     Style="{StaticResource Body1FontSize_ExoBold}"
                     Text="Location Settings"
                     VerticalTextAlignment="Center" />
-                
+
                 <materialDesignControls1:MaterialPicker
-                    Grid.Row="2"
-                    FontSize="16"
-                    CornerRadius="10"
-                    ItemsSource="{Binding LocationSelectionList}"
-                    Margin="30,60,30,0"
-                    LabelText="Select Destination"
-                    Placeholder="Select Destination"
-                    LabelSize="16"
-                    LabelTextColor="Black"
                     BackgroundColor="White"
-                    SelectedItem="{Binding SelectedLocation}"/>
-                
+                    CornerRadius="10"
+                    FontSize="16"
+                    Grid.Row="2"
+                    ItemsSource="{Binding LocationSelectionList}"
+                    LabelSize="16"
+                    LabelText="Select Destination"
+                    LabelTextColor="Black"
+                    Margin="30,60,30,0"
+                    Placeholder="Select Destination"
+                    SelectedItem="{Binding SelectedLocation}" />
+
                 <StackLayout
                     Grid.Row="3"
                     HeightRequest="20"
                     Orientation="Horizontal"
                     Spacing="10">
-                    <CheckBox Color="Black" IsChecked="{Binding IsCurrentLocationEnabled, Mode=TwoWay}" Margin="30,0,0,0" />
+                    <CheckBox
+                        Color="Black"
+                        IsChecked="{Binding IsCurrentLocationEnabled, Mode=TwoWay}"
+                        Margin="30,0,0,0" />
                     <Label
                         Text="Use Current Location"
                         TextColor="Black"
                         VerticalOptions="Center" />
                 </StackLayout>
-                
-                <Grid
-                    Grid.Row="4"
-                    IsEnabled="{Binding m_IsOtherLocationEnabled}">
+
+                <Grid Grid.Row="4" IsEnabled="{Binding m_IsOtherLocationEnabled}">
                     <Grid.ColumnDefinitions>
                         <ColumnDefinition Width="*" />
                     </Grid.ColumnDefinitions>
 
                     <materialDesignControls1:MaterialEntry
+                        BackgroundColor="{Binding EntryBackgroundColor}"
+                        BorderColor="Transparent"
+                        CornerRadius="10"
                         FontSize="16"
                         Grid.Column="0"
                         HeightRequest="70"
-                        CornerRadius="10"
-                        Margin="30,30,30,0"
-                        LabelText="Enter Address"
-                        Placeholder="Enter Address"
                         LabelSize="16"
+                        LabelText="Enter Address"
                         LabelTextColor="Black"
-                        PlaceholderColor="Gray"
-                        BackgroundColor="{Binding EntryBackgroundColor}"
-                        BorderColor="Transparent"
+                        Margin="30,30,30,0"
                         MaxLength="100"
+                        Placeholder="Enter Address"
+                        PlaceholderColor="Gray"
                         ReturnType="Next"
                         TabIndex="1"
                         Text="{Binding SearchAddress}"
                         TextColor="Black" />
                 </Grid>
-                
-                <Grid
-                    Grid.Row="5"
-                    IsEnabled="{Binding m_IsOtherLocationEnabled}">
+
+                <Grid Grid.Row="5" IsEnabled="{Binding m_IsOtherLocationEnabled}">
                     <Grid.ColumnDefinitions>
                         <ColumnDefinition Width="*" />
                     </Grid.ColumnDefinitions>
 
                     <materialDesignControls1:MaterialPicker
+                        BackgroundColor="{Binding EntryBackgroundColor}"
+                        CornerRadius="10"
                         FontSize="16"
                         Grid.Column="0"
                         HeightRequest="70"
-                        CornerRadius="10"
-                        Margin="30,10,30,0"
-                        LabelText="Suggestions"
-                        Placeholder="Suggestions"
                         LabelSize="16"
+                        LabelText="Suggestions"
                         LabelTextColor="Black"
+                        Margin="30,10,30,0"
+                        Placeholder="Suggestions"
                         PlaceholderColor="Gray"
-                        BackgroundColor="{Binding EntryBackgroundColor}"
                         SelectedItem="{Binding SelectedAddress}">
                         <materialDesignControls1:MaterialPicker.ItemsSource>
                             <Binding Path="DropBoxOptions" />
@@ -116,24 +115,24 @@
                 </Grid>
 
                 <Button
-                    Grid.Row="6"
-                    Margin="80,20,80,20"
                     BackgroundColor="{AppThemeBinding Light={StaticResource LightButtonColor},
                                                       Dark={StaticResource DarkButtonColor}}"
                     Command="{Binding GetAddressSuggestionsCommand}"
-                    IsEnabled="{Binding m_IsOtherLocationEnabled}"
                     CornerRadius="30"
+                    Grid.Row="6"
+                    IsEnabled="{Binding m_IsOtherLocationEnabled}"
+                    Margin="80,20,80,20"
                     Text="Get Address Suggestion"
                     TextColor="{AppThemeBinding Light={StaticResource LightButtonTextColor},
                                                 Dark={StaticResource DarkButtonTextColor}}" />
-                
+
                 <Button
-                    Grid.Row="9"
-                    Margin="50,-15,50,180"
                     BackgroundColor="{AppThemeBinding Light={StaticResource LightButtonColor},
                                                       Dark={StaticResource DarkButtonColor}}"
                     Command="{Binding UpdateLocationCommand}"
                     CornerRadius="30"
+                    Grid.Row="9"
+                    Margin="50,-15,50,180"
                     Text="UPDATE LOCATION"
                     TextColor="{AppThemeBinding Light={StaticResource LightButtonTextColor},
                                                 Dark={StaticResource DarkButtonTextColor}}" />

--- a/Notify/Notify/Notify/Views/LoginPage.xaml
+++ b/Notify/Notify/Notify/Views/LoginPage.xaml
@@ -5,6 +5,7 @@
     xmlns="http://xamarin.com/schemas/2014/forms"
     xmlns:material="clr-namespace:Plugin.MaterialDesignControls;assembly=Plugin.MaterialDesignControls"
     xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml">
+
     <RefreshView IsRefreshing="{Binding IsBusy}">
         <Grid>
             <Image
@@ -32,7 +33,7 @@
                         BackgroundColor="#222831"
                         BorderColor="#222831"
                         HorizontalOptions="FillAndExpand"
-                        Opacity="0.65"
+                        Opacity="0.8"
                         Padding="0">
                         <StackLayout Orientation="Horizontal">
                             <!--  User Name  -->
@@ -69,7 +70,7 @@
                         BorderColor="#222831"
                         HorizontalOptions="FillAndExpand"
                         Margin="0,15,0,0"
-                        Opacity="0.65"
+                        Opacity="0.8"
                         Padding="0">
                         <StackLayout Orientation="Horizontal">
                             <Frame

--- a/Notify/Notify/Notify/Views/NotificationCreationPage.xaml
+++ b/Notify/Notify/Notify/Views/NotificationCreationPage.xaml
@@ -3,7 +3,6 @@
     x:Class="Notify.Views.NotificationCreationPage"
     xmlns="http://xamarin.com/schemas/2014/forms"
     xmlns:materialDesignControls="clr-namespace:Plugin.MaterialDesignControls;assembly=Plugin.MaterialDesignControls"
-    xmlns:views="clr-namespace:Notify.Views.Views;assembly=Notify"
     xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml">
     <FlexLayout
         BackgroundColor="{AppThemeBinding Light={StaticResource LightPageBackgroundColor},

--- a/Notify/Notify/Notify/Views/NotificationsPage.xaml
+++ b/Notify/Notify/Notify/Views/NotificationsPage.xaml
@@ -32,6 +32,7 @@
             <Grid.RowDefinitions>
                 <RowDefinition Height="140" />
                 <RowDefinition Height="40" />
+                <RowDefinition Height="Auto" />
                 <RowDefinition Height="*" />
             </Grid.RowDefinitions>
 
@@ -39,6 +40,7 @@
                 BackgroundColor="#F3F5F9"
                 HorizontalOptions="FillAndExpand"
                 VerticalOptions="FillAndExpand">
+
                 <StackLayout
                     HorizontalOptions="Center"
                     Margin="0,-40,0,0"
@@ -61,6 +63,7 @@
                     </Label>
                 </StackLayout>
             </Grid>
+
             <SearchBar
                 BackgroundColor="WhiteSmoke"
                 Grid.Row="0"
@@ -71,48 +74,57 @@
                 SearchCommand="{Binding ExecuteSearchCommand}"
                 SearchCommandParameter="{Binding .}"
                 Text="{Binding SearchTerm}" />
+
             <ActivityIndicator
                 Color="#393E46"
                 IsRunning="{Binding IsLoading}"
                 IsVisible="{Binding IsLoading}" />
-            <CollectionView
+
+            <materialDesignControls:MaterialPicker
+                BackgroundColor="Transparent"
+                BorderColor="Transparent"
+                Grid.Column="0"
                 Grid.Row="2"
+                ItemsSource="{Binding FilterTypes}"
+                Margin="0,-30,0,0"
+                Placeholder="Filter by"
+                PlaceholderColor="Black"
+                SelectedItem="{Binding SelectedFilter}"
+                TextColor="Black" />
+
+            <Label
+                FontAttributes="Bold"
+                FontSize="Large"
+                Grid.Row="2"
+                HorizontalOptions="End"
+                Margin="0,-20,20,0"
+                Text="+"
+                TextColor="Black">
+                <Label.GestureRecognizers>
+                    <TapGestureRecognizer Command="{Binding CreateNotificationCommand}" />
+                </Label.GestureRecognizers>
+            </Label>
+
+            <CollectionView
+                Grid.Row="3"
                 HorizontalOptions="FillAndExpand"
                 ItemsSource="{Binding FilteredNotifications}"
-                Margin="15,-10,15,0"
+                Margin="15,-20,15,0"
                 SelectionMode="None"
                 VerticalOptions="FillAndExpand"
                 VerticalScrollBarVisibility="Always">
+
                 <CollectionView.Header>
                     <Grid>
                         <Grid.ColumnDefinitions>
                             <ColumnDefinition Width="*" />
                             <ColumnDefinition Width="Auto" />
                         </Grid.ColumnDefinitions>
-                        <materialDesignControls:MaterialPicker
-                            BackgroundColor="Transparent"
-                            BorderColor="Transparent"
-                            Grid.Column="0"
-                            ItemsSource="{Binding FilterTypes}"
-                            Placeholder="Filter by"
-                            PlaceholderColor="Black"
-                            SelectedItem="{Binding SelectedFilter}" />
-                        <Label
-                            FontAttributes="Bold"
-                            FontSize="Large"
-                            Grid.Column="1"
-                            HorizontalOptions="End"
-                            Margin="0,0,10,0"
-                            Text="+"
-                            TextColor="Black">
-                            <Label.GestureRecognizers>
-                                <TapGestureRecognizer Command="{Binding CreateNotificationCommand}" />
-                            </Label.GestureRecognizers>
-                        </Label>
+
                     </Grid>
                 </CollectionView.Header>
                 <CollectionView.ItemsLayout>
-                    <LinearItemsLayout ItemSpacing="20" Orientation="Vertical" />
+                    <LinearItemsLayout ItemSpacing="10" Orientation="Vertical" />
                 </CollectionView.ItemsLayout>
                 <CollectionView.ItemTemplate>
                     <DataTemplate>
@@ -131,6 +143,7 @@
                                     </SwipeItem>
                                 </SwipeItems>
                             </SwipeView.LeftItems>
+
                             <SwipeView.RightItems>
                                 <SwipeItems Mode="Reveal">
                                     <SwipeItem
@@ -168,21 +181,25 @@
                                     </SwipeItem>
                                 </SwipeItems>
                             </SwipeView.RightItems>
+
                             <SwipeView.Content>
                                 <pancakeView:PancakeView
                                     BackgroundColor="White"
                                     HorizontalOptions="FillAndExpand"
                                     VerticalOptions="StartAndExpand">
                                     <Grid HorizontalOptions="FillAndExpand" VerticalOptions="StartAndExpand">
+
                                         <Grid.ColumnDefinitions>
                                             <ColumnDefinition Width="Auto" />
                                             <ColumnDefinition Width="*" />
                                         </Grid.ColumnDefinitions>
+
                                         <BoxView
                                             BackgroundColor="{Binding Type, Converter={StaticResource TypeToColorConverter}}"
                                             HorizontalOptions="Start"
                                             VerticalOptions="FillAndExpand"
                                             WidthRequest="3" />
+
                                         <views:Expander Grid.Column="1" IsExpanded="{Binding ID, Converter={StaticResource IdToIsExpandedConverter}, ConverterParameter={Binding Source={x:Reference NotificationForm}, Path=BindingContext.ExpandedNotificationId}}">
                                             <views:Expander.Header>
                                                 <Grid HorizontalOptions="FillAndExpand">
@@ -191,6 +208,7 @@
                                                         <ColumnDefinition Width="Auto" />
                                                         <ColumnDefinition Width="3.5*" />
                                                     </Grid.ColumnDefinitions>
+
                                                     <StackLayout HorizontalOptions="Center" VerticalOptions="Center">
                                                         <Image
                                                             Aspect="AspectFill"
@@ -198,22 +216,26 @@
                                                             HorizontalOptions="Center"
                                                             Source="{Binding Type, Converter={StaticResource TypeToIconConverter}}" />
                                                     </StackLayout>
+
                                                     <BoxView
                                                         BackgroundColor="#F2F4F8"
                                                         Grid.Column="1"
                                                         HorizontalOptions="Start"
                                                         VerticalOptions="FillAndExpand"
                                                         WidthRequest="1" />
+
                                                     <StackLayout
                                                         Grid.Column="2"
                                                         HorizontalOptions="Start"
                                                         Margin="20,20,20,20"
                                                         VerticalOptions="Center">
+
                                                         <Label
                                                             FontAttributes="Bold"
                                                             FontSize="Medium"
                                                             Text="{Binding Name}"
                                                             TextColor="Black" />
+
                                                         <Label
                                                             FontSize="Medium"
                                                             Margin="0,-5,0,0"
@@ -222,18 +244,21 @@
                                                     </StackLayout>
                                                 </Grid>
                                             </views:Expander.Header>
+
                                             <Grid HorizontalOptions="FillAndExpand">
                                                 <Grid.ColumnDefinitions>
                                                     <ColumnDefinition Width="*" />
                                                     <ColumnDefinition Width="Auto" />
                                                     <ColumnDefinition Width="3.5*" />
                                                 </Grid.ColumnDefinitions>
+
                                                 <BoxView
                                                     BackgroundColor="#F2F4F8"
                                                     Grid.Column="1"
                                                     HorizontalOptions="Start"
                                                     VerticalOptions="FillAndExpand"
                                                     WidthRequest="1" />
+
                                                 <StackLayout Grid.Column="2" Spacing="10">
                                                     <Label
                                                         FontAttributes="Bold"
@@ -242,6 +267,7 @@
                                                         Opacity="0.8"
                                                         Text="{Binding Status, StringFormat='Status: {0}'}"
                                                         TextColor="#2F3246" />
+
                                                     <Label
                                                         FontAttributes="Bold"
                                                         FontSize="Small"
@@ -249,6 +275,7 @@
                                                         Opacity="0.8"
                                                         Text="{Binding Creator, StringFormat='Creator: {0}'}"
                                                         TextColor="#2F3246" />
+
                                                     <Label
                                                         FontAttributes="Bold"
                                                         FontSize="Small"
@@ -256,12 +283,14 @@
                                                         Opacity="0.8"
                                                         Text="{Binding CreationDateTime, StringFormat='Creation Date: {0}'}"
                                                         TextColor="#2F3246" />
+
                                                     <Label
                                                         FontAttributes="Bold"
                                                         FontSize="Small"
                                                         Margin="20,0"
                                                         Opacity="0.8"
                                                         TextColor="#2F3246">
+
                                                         <Label.FormattedText>
                                                             <FormattedString>
                                                                 <Span Text="{Binding Type, Converter={StaticResource TypeInfoConverter}}" />
@@ -270,6 +299,7 @@
                                                             </FormattedString>
                                                         </Label.FormattedText>
                                                     </Label>
+
                                                     <Label
                                                         FontAttributes="Bold"
                                                         FontSize="Small"
@@ -278,6 +308,7 @@
                                                         Opacity="0.8"
                                                         Text="{Binding Activation, StringFormat='Activate on: {0}'}"
                                                         TextColor="#2F3246" />
+
                                                     <Label
                                                         FontAttributes="Bold"
                                                         FontSize="Small"
@@ -286,18 +317,21 @@
                                                         Opacity="0.8"
                                                         Text="{Binding IsPermanent, StringFormat='Permanent: {0}'}"
                                                         TextColor="#2F3246" />
+
                                                     <Label
                                                         FontAttributes="Bold"
                                                         FontSize="Small"
-                                                        Margin="20,1"
+                                                        Margin="20,0,20,10"
                                                         Opacity="0.8"
                                                         Text="{Binding Target, StringFormat='Target User: {0}'}"
                                                         TextColor="#2F3246" />
+
                                                     <StackLayout
                                                         IsVisible="{Binding IsDynamicLocation}"
                                                         Margin="20,0,20,10"
                                                         Orientation="Horizontal"
                                                         Spacing="5">
+
                                                         <Label
                                                             FontAttributes="Bold"
                                                             FontSize="Small"
@@ -305,6 +339,7 @@
                                                             Text="Open in:"
                                                             TextColor="#2F3246"
                                                             VerticalOptions="Center" />
+
                                                         <ImageButton
                                                             BackgroundColor="Transparent"
                                                             Command="{Binding Path=BindingContext.OpenMapCommand, Source={RelativeSource AncestorType={x:Type CollectionView}}}"

--- a/Notify/Notify/Notify/Views/WifiSettingsPage.xaml
+++ b/Notify/Notify/Notify/Views/WifiSettingsPage.xaml
@@ -3,75 +3,75 @@
     NavigationPage.HasNavigationBar="False"
     x:Class="Notify.Views.WifiSettingsPage"
     xmlns="http://xamarin.com/schemas/2014/forms"
-    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
-    xmlns:materialDesignControls="clr-namespace:Plugin.MaterialDesignControls;assembly=Plugin.MaterialDesignControls">
+    xmlns:materialDesignControls="clr-namespace:Plugin.MaterialDesignControls;assembly=Plugin.MaterialDesignControls"
+    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml">
     <ContentPage.Content>
         <ScrollView>
 
             <Grid
                 BackgroundColor="{AppThemeBinding Light={StaticResource LightPageBackgroundColor},
                                                   Dark={StaticResource DarkPageBackgroundColor}}"
-                Row="9"
-                RowDefinitions="Auto, Auto, Auto, Auto, Auto, Auto, Auto, Auto, *">
-                
+                Row="6"
+                RowDefinitions="Auto, Auto, Auto, Auto, Auto, *">
+
                 <Button
-                    Grid.Row="0"
-                    Margin="-20, 0, 0, 0"
                     Background="Transparent"
                     BackgroundColor="Transparent"
                     Command="{Binding BackCommand}"
                     FontAttributes="Bold"
                     FontSize="25"
+                    Grid.Row="0"
                     HorizontalOptions="Start"
+                    Margin="-20,0,0,0"
                     Text="❮"
                     TextColor="{AppThemeBinding Light={StaticResource DarkButtonTextColor},
                                                 Dark={StaticResource LightEntryBackgroundColor}}"
                     VerticalOptions="Start" />
-                
+
                 <Label
-                    Grid.Row="1"
                     FontAttributes="Bold"
                     FontSize="30"
+                    Grid.Row="1"
                     HorizontalTextAlignment="Center"
                     Style="{StaticResource Body1FontSize_ExoBold}"
                     Text="Wi-Fi Settings"
                     VerticalTextAlignment="Center" />
-                
-                <materialDesignControls:MaterialPicker
-                    Grid.Row="2"
-                    CornerRadius="10"
-                    LabelMargin="3"
-                    LabelSize="16"
-                    Margin="30,60,30,0"
-                    LabelText="Select Wi-Fi"
-                    Placeholder="Select Wi-Fi"
-                    LabelTextColor="Black"
-                    BackgroundColor="White"
-                    ItemsSource="{Binding WiFiSelectionList}"
-                    SelectedItem="{Binding SelectedWiFiSSID}"
-                    TabIndex="1"/>
 
                 <materialDesignControls:MaterialPicker
-                    Grid.Row="3"
+                    BackgroundColor="White"
                     CornerRadius="10"
+                    Grid.Row="2"
+                    ItemsSource="{Binding WiFiSelectionList}"
                     LabelMargin="3"
                     LabelSize="16"
-                    Margin="30,20,30,0"
-                    LabelText="Select Location"
-                    Placeholder="Select Location"
+                    LabelText="Select Wi-Fi"
                     LabelTextColor="Black"
+                    Margin="30,60,30,0"
+                    Placeholder="Select Wi-Fi"
+                    SelectedItem="{Binding SelectedWiFiSSID}"
+                    TabIndex="1" />
+
+                <materialDesignControls:MaterialPicker
                     BackgroundColor="White"
+                    CornerRadius="10"
+                    Grid.Row="3"
                     ItemsSource="{Binding LocationSelectionList}"
+                    LabelMargin="3"
+                    LabelSize="16"
+                    LabelText="Select Location"
+                    LabelTextColor="Black"
+                    Margin="30,20,30,0"
+                    Placeholder="Select Location"
                     SelectedItem="{Binding SelectedLocation}"
-                    TabIndex="1"/>
-                
+                    TabIndex="1" />
+
                 <Button
-                    Grid.Row="9"
-                    Margin="50,80,50,180"
                     BackgroundColor="{AppThemeBinding Light={StaticResource LightButtonColor},
                                                       Dark={StaticResource DarkButtonColor}}"
                     Command="{Binding UpdateWifiSettingsCommand}"
                     CornerRadius="30"
+                    Grid.Row="4"
+                    Margin="50,80,50,180"
                     Text="UPDATE Wi-Fi"
                     TextColor="{AppThemeBinding Light={StaticResource LightButtonTextColor},
                                                 Dark={StaticResource DarkButtonTextColor}}" />


### PR DESCRIPTION
## Description: 
Turn pending time notifications to "Expired" if their time elapsed.

## Type of change:
- [ ] Bug fix
- [ ] New feature
- [x] Fix/new infrastructure

## Background context of the changes:
When a time notification is being created by a friend, which doesn't have the permission to create an "automatically-accepted" time notification, the notification shouldn't stay on "Pending" status when its time elapses.

## The ticket this PR closes:
[NOTIFY-194](https://ofirlindekel.atlassian.net/browse/NOTIFY-194)

## Scenarios that were tested during this implementation:
- A time notification is being created by a permitted user - the notification gets "Active" status and being triggered.
- A time notification is being created by a not-permitted user and its time elapsed - the notification gets "Expired" status and not being triggered.
- - A time notification is being created by a not-permitted user and its time not elapsed - the notification gets "Pending" status and being activated.
