### PR TITLE
Send newsfeeds as notifications

### DIFF
--- a/Notify/Notify.Functions/Notify.Functions/NotifyFunctions/Notification/CreateNotification.cs
+++ b/Notify/Notify.Functions/Notify.Functions/NotifyFunctions/Notification/CreateNotification.cs
@@ -96,7 +96,8 @@ namespace Notify.Functions.NotifyFunctions.Notification
                             extraElement
                         }
                     },
-                    { "user", user }
+                    { "user", user },
+                    { "shouldBeNotified", Convert.ToString(json["shouldBeNotified"] ?? user) }
                 };
 
                 if (type.ToLower().Equals(Constants.NOTIFICATION_TYPE_LOCATION_LOWER))

--- a/Notify/Notify/Notify.Android/MainActivity.cs
+++ b/Notify/Notify/Notify.Android/MainActivity.cs
@@ -142,13 +142,16 @@ namespace Notify.Droid
                 string message = intent.GetStringExtra(AndroidNotificationManager.messageKey);
                 string data = intent.GetStringExtra(AndroidNotificationManager.dataKey);
                 Notification notification = Newtonsoft.Json.JsonConvert.DeserializeObject<Notification>(data);
-
                 NotificationsPageViewModel viewModel = NotificationsPageViewModel.Instance;
-                viewModel.ExpandedNotificationId = notification.ID;
-                viewModel.SelectedFilter = Constants.FILTER_TYPE_ALL;
                 
                 DependencyService.Get<INotificationManager>().ReceiveNotification(title, message, notification);
-                App.Current.MainPage.Navigation.PushAsync(new NotificationsPage(viewModel));
+
+                if (notification != null)
+                {
+                    viewModel.ExpandedNotificationId = notification.ID;
+                    viewModel.SelectedFilter = Constants.FILTER_TYPE_ALL;
+                    App.Current.MainPage.Navigation.PushAsync(new NotificationsPage(viewModel));
+                }
             }
         }
     }

--- a/Notify/Notify/Notify.Android/Managers/AndroidWiFiManager.cs
+++ b/Notify/Notify/Notify.Android/Managers/AndroidWiFiManager.cs
@@ -147,8 +147,16 @@ namespace Notify.Droid.Managers
                     {
                         if (isArrivalNotification)
                         {
-                            r_Logger.LogInformation($"Sending notification for arrival notification: {notification.Name}");
-                            DependencyService.Get<INotificationManager>().SendNotification(notification);
+                            if (notification.ShouldBeNotified.Equals(notification.Creator))
+                            {
+                                r_Logger.LogInformation($"Sending newsfeed to creator {notification.Creator} for arrival notification: {notification.Name}");
+                                 AzureHttpClient.Instance.SendNewsfeed(new Newsfeed(notification.Creator, $"{notification.Target} Arrived {notification.TypeInfo}", $"{notification.Target} has arrived to {notification.TypeInfo}"));
+                            }
+                            else
+                            {
+                                r_Logger.LogInformation($"Sending notification for arrival notification: {notification.Name}");
+                                DependencyService.Get<INotificationManager>().SendNotification(notification);
+                            }
                             
                             if (notification.IsPermanent)
                             {
@@ -191,8 +199,16 @@ namespace Notify.Droid.Managers
                     {
                         if (isLeaveNotification)
                         {
-                            r_Logger.LogInformation($"Sending notification for leave notification: {notification.Name}");
-                            DependencyService.Get<INotificationManager>().SendNotification(notification);
+                            if(notification.ShouldBeNotified.Equals(notification.Creator))
+                            {
+                                r_Logger.LogInformation($"Sending newsfeed to creator {notification.Creator} for leave notification: {notification.Name}");
+                                AzureHttpClient.Instance.SendNewsfeed(new Newsfeed(notification.Creator, $"{notification.Target} Left {notification.TypeInfo}", $"{notification.Target} has left {notification.TypeInfo}"));
+                            }
+                            else
+                            {
+                                r_Logger.LogInformation($"Sending notification for leave notification: {notification.Name}");
+                                DependencyService.Get<INotificationManager>().SendNotification(notification);
+                            }
                             
                             if(notification.IsPermanent)
                             {

--- a/Notify/Notify/Notify.Android/Notifications/AndroidNotificationManager.cs
+++ b/Notify/Notify/Notify.Android/Notifications/AndroidNotificationManager.cs
@@ -1,15 +1,16 @@
 using System;
 using Android.App;
 using Android.Content;
-using Android.Graphics;
 using Android.OS;
 using AndroidX.Core.App;
 using Newtonsoft.Json;
+using Notify.Core;
 using Notify.Helpers;
 using Notify.Notifications;
 using Notify.Services;
 using Xamarin.Forms;
 using AndroidApp = Android.App.Application;
+using Notification = Android.App.Notification;
 
 [assembly: Dependency(typeof(Notify.Droid.Notifications.AndroidNotificationManager))]
 namespace Notify.Droid.Notifications
@@ -158,6 +159,21 @@ namespace Notify.Droid.Notifications
             long utcAlarmTime = utcTime.AddSeconds(-epochDiff).Ticks / 10000;
 
             return utcAlarmTime; // milliseconds
+        }
+        
+        public void SendNewsfeed(Newsfeed newsfeed)
+        {
+            r_Logger.LogDebug($"Sending newsfeed with title: {newsfeed.Title} and content: {newsfeed.Content}");
+            
+            try
+            {
+                DependencyService.Get<INotificationManager>()
+                    .SendNotification(newsfeed.Title, newsfeed.Content, null);
+            }
+            catch (Exception ex)
+            {
+                r_Logger.LogError($"Error sending notification: {ex.Message}");
+            }
         }
     }
 }

--- a/Notify/Notify/Notify/AppShell.xaml.cs
+++ b/Notify/Notify/Notify/AppShell.xaml.cs
@@ -143,7 +143,7 @@ namespace Notify
 
                 foreach (Newsfeed newsfeed in newsfeeds)
                 {
-                    LoggerService.Instance.LogDebug($"Sending newsfeed {newsfeed.ID}");
+                    LoggerService.Instance.LogDebug($"Sending newsfeed: {newsfeed.Title}, {newsfeed.Content}");
                     DependencyService.Get<INotificationManager>().SendNewsfeed(newsfeed);
                 }
                 

--- a/Notify/Notify/Notify/Azure/HttpClient/AzureHttpClient.cs
+++ b/Notify/Notify/Notify/Azure/HttpClient/AzureHttpClient.cs
@@ -1081,5 +1081,13 @@ namespace Notify.Azure.HttpClient
 
             return await m_HttpClient.SendAsync(request);
         }
+
+        public async Task<List<Newsfeed>> GetNewsfeeds()
+        {
+            return await GetData(
+                endpoint: Constants.AZURE_FUNCTIONS_PATTERN_NEWSFEED,
+                preferencesKey: Constants.PREFERENCES_NEWSFEED, 
+                converter: Converter.ToNewsfeed);
+        }
     }
 }

--- a/Notify/Notify/Notify/Azure/HttpClient/AzureHttpClient.cs
+++ b/Notify/Notify/Notify/Azure/HttpClient/AzureHttpClient.cs
@@ -10,6 +10,7 @@ using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using Notify.Core;
 using Notify.Helpers;
+using Notify.Notifications;
 using Notify.Services;
 using Notify.WiFi;
 using Xamarin.Essentials;
@@ -281,6 +282,8 @@ namespace Notify.Azure.HttpClient
             createNewDynamicDestinations(notifications);
             DependencyService.Get<IWiFiManager>().SendNotifications(null, null);
 
+            GetNewsfeedsAndSendThem();
+
             return notifications;
         }
 
@@ -457,6 +460,7 @@ namespace Notify.Azure.HttpClient
         
         public async Task<List<User>> GetFriends()
         {
+            GetNewsfeedsAndSendThem();
             await GetFriendsPermissions();
             
             return await GetData(
@@ -1088,6 +1092,45 @@ namespace Notify.Azure.HttpClient
                 endpoint: Constants.AZURE_FUNCTIONS_PATTERN_NEWSFEED,
                 preferencesKey: Constants.PREFERENCES_NEWSFEED, 
                 converter: Converter.ToNewsfeed);
+        }
+
+        public async void GetNewsfeedsAndSendThem()
+        {
+            List<Newsfeed> newsfeeds = await GetNewsfeeds();
+            
+            foreach (Newsfeed newsfeed in newsfeeds)
+            {
+                DependencyService.Get<INotificationManager>().SendNewsfeed(newsfeed);
+            }
+        }
+
+        public void SendNewsfeed(Newsfeed newsfeed)
+        {
+            HttpResponseMessage response;
+            string json;
+            dynamic data = new JObject
+            {
+                { "username", newsfeed.Username },
+                { "title", newsfeed.Title },
+                { "content", newsfeed.Content },
+            };
+            
+            json = JsonConvert.SerializeObject(data);
+            r_Logger.LogInformation($"request:{Environment.NewLine}{json}");
+
+            try
+            {
+                response = postAsync(
+                    requestUri: Constants.AZURE_FUNCTIONS_PATTERN_NEWSFEED,
+                    content: createJsonStringContent(json)).Result;
+
+                response.EnsureSuccessStatusCode();
+                r_Logger.LogInformation($"Successful status code from Azure Function from SendNewsfeeds");
+            }
+            catch (Exception ex)
+            {
+                r_Logger.LogError($"Error occurred on SendNewsfeeds: {ex.Message}");
+            }
         }
     }
 }

--- a/Notify/Notify/Notify/Core/Newsfeed.cs
+++ b/Notify/Notify/Notify/Core/Newsfeed.cs
@@ -1,0 +1,16 @@
+namespace Notify.Core
+{
+    public class Newsfeed
+    {
+        public string ID { get; set; }
+        public string Title { get; set; }
+        public string Content { get; set; }
+        
+        public Newsfeed(string id, string title, string content)
+        {
+            ID = id;
+            Title = title;
+            Content = content;
+        }
+    }
+}

--- a/Notify/Notify/Notify/Core/Newsfeed.cs
+++ b/Notify/Notify/Notify/Core/Newsfeed.cs
@@ -2,13 +2,13 @@ namespace Notify.Core
 {
     public class Newsfeed
     {
-        public string ID { get; set; }
+        public string Username { get; set; }
         public string Title { get; set; }
         public string Content { get; set; }
         
-        public Newsfeed(string id, string title, string content)
+        public Newsfeed(string username, string title, string content)
         {
-            ID = id;
+            Username = username;
             Title = title;
             Content = content;
         }

--- a/Notify/Notify/Notify/Core/Notification.cs
+++ b/Notify/Notify/Notify/Core/Notification.cs
@@ -25,6 +25,7 @@ namespace Notify.Core
         public string Activation { get; set; }
         public bool IsPermanent { get; set; }
         public string Target { get; set; }
+        public string ShouldBeNotified { get; set; }
         
         public bool IsPending => Status == Constants.NOTIFICATION_STATUS_PENDING;
         public bool IsRenewable => Status == Constants.NOTIFICATION_STATUS_EXPIRED && Type != NotificationType.Time;
@@ -37,7 +38,7 @@ namespace Notify.Core
             
         }
         
-        public Notification(string id, string name, string description, DateTime creationDateTime, string status, string creator, NotificationType type, object typeInfo, string target, string activation, bool permanent)
+        public Notification(string id, string name, string description, DateTime creationDateTime, string status, string creator, NotificationType type, object typeInfo, string target, string activation, bool permanent, string shouldBeNotified)
         {
             ID = id;
             Name = name;
@@ -50,6 +51,7 @@ namespace Notify.Core
             Activation = activation;
             IsPermanent = permanent;
             Target = target;
+            ShouldBeNotified = shouldBeNotified;
         }
         
         public Notification(string id)

--- a/Notify/Notify/Notify/Helpers/Constants.cs
+++ b/Notify/Notify/Notify/Helpers/Constants.cs
@@ -142,6 +142,7 @@ namespace Notify.Helpers
         public static readonly string AZURE_FUNCTIONS_PATTERN_NOTIFICATION_UPDATE_DYNAMIC = $"{AZURE_FUNCTIONS_PATTERN_NOTIFICATION_UPDATE}/dynamic";
         public static readonly string AZURE_FUNCTIONS_PATTERN_NOTIFICATION_UPDATE_STATUS = $"{AZURE_FUNCTIONS_PATTERN_NOTIFICATION}/status";
         public static readonly string AZURE_FUNCTIONS_PATTERN_NOTIFICATION_RENEW = $"{AZURE_FUNCTIONS_PATTERN_NOTIFICATION}/renew";
+        public static readonly string AZURE_FUNCTIONS_PATTERN_NEWSFEED = "newsfeed";
         public static readonly string AZURE_FUNCTIONS_PATTERN_DESTINATION = "destination";
         public static readonly string AZURE_FUNCTIONS_PATTERN_DESTINATION_UPDATE = AZURE_FUNCTIONS_PATTERN_DESTINATION + "/update";
         public static readonly string AZURE_FUNCTIONS_PATTERN_DESTINATION_SUGGESTIONS = AZURE_FUNCTIONS_PATTERN_DESTINATION + "/suggestions";
@@ -198,6 +199,7 @@ namespace Notify.Helpers
         #region Prefrences_Keys
 
         public static readonly string PREFERENCES_NOTIFICATIONS = "Notifications";
+        public static readonly string PREFERENCES_NEWSFEED = "Newsfeed";
         public static readonly string PREFERENCES_DESTINATIONS = "Destinations";
         public static readonly string PREFERENCES_FRIENDS = "Friends";
         public static readonly string PREFERENCES_PENDING_FRIEND_REQUESTS = "PendingFriendRequests";

--- a/Notify/Notify/Notify/Helpers/Converter.cs
+++ b/Notify/Notify/Notify/Helpers/Converter.cs
@@ -282,5 +282,13 @@ namespace Notify.Helpers
                 timeNotificationPermission: (string)permission.time,
                 dynamicNotificationPermission: (string)permission.dynamic);
         }
+        
+        public static Newsfeed ToNewsfeed(dynamic newsfeed)
+        {
+            return new Newsfeed(
+                id: (string)newsfeed.id,
+                title: (string)newsfeed.title,
+                content: (string)newsfeed.content);
+        }
     }
 }

--- a/Notify/Notify/Notify/Helpers/Converter.cs
+++ b/Notify/Notify/Notify/Helpers/Converter.cs
@@ -230,7 +230,8 @@ namespace Notify.Helpers
                 typeInfo: notificationTypeValue,
                 activation: activation,
                 permanent: notification.notification.permanent != null && (bool)notification.notification.permanent,
-                target: (string)notification.user);
+                target: (string)notification.user,
+                shouldBeNotified: (string)notification.shouldBeNotified ?? (string)notification.user);
         }
         
         public static User ToFriend(dynamic friend)
@@ -286,7 +287,7 @@ namespace Notify.Helpers
         public static Newsfeed ToNewsfeed(dynamic newsfeed)
         {
             return new Newsfeed(
-                id: (string)newsfeed.id,
+                username: (string)newsfeed.username,
                 title: (string)newsfeed.title,
                 content: (string)newsfeed.content);
         }

--- a/Notify/Notify/Notify/Notifications/INotificationManager.cs
+++ b/Notify/Notify/Notify/Notifications/INotificationManager.cs
@@ -8,6 +8,7 @@ namespace Notify.Notifications
         event EventHandler NotificationReceived;
         void Initialize();
         void SendNotification(Notification notification);
+        void SendNewsfeed(Newsfeed newsfeed);
         void SendNotification(string title, string message, Notification notification, DateTime? notifyTime = null);
         void ReceiveNotification(string title, string message, Notification notification);
     }


### PR DESCRIPTION
## Description: 
Get newsfeeds from Azure Functions as send them as notifications on Notify's application.

## Type of change:
- [ ] Bug fix
- [ ] New feature
- [x] Fix/new infrastructure

## The ticket this PR closes:
[NOTIFY-204](https://ofirlindekel.atlassian.net/browse/NOTIFY-204)

## Scenarios that were tested during this implementation:
- A real notification is received and clicked on - works as before.
- A newsfeed notification is received as clicked on - application opens and nothing happens (as expected).
